### PR TITLE
feat: add 3 premium video models, I2V support, and parameter tuning

### DIFF
--- a/src/components/business/VideoGenerateForm.tsx
+++ b/src/components/business/VideoGenerateForm.tsx
@@ -1,7 +1,15 @@
 'use client'
 
-import { useCallback, useState } from 'react'
-import { AlertCircle, Film, Loader2 } from 'lucide-react'
+import { useCallback, useRef, useState } from 'react'
+import {
+  AlertCircle,
+  ChevronDown,
+  ChevronUp,
+  Film,
+  Loader2,
+  Upload,
+  X,
+} from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl'
 
 import {
@@ -9,7 +17,7 @@ import {
   GENERATION_LIMITS,
   VIDEO_GENERATION,
 } from '@/constants/config'
-import { getAvailableVideoModels } from '@/constants/models'
+import { getAvailableVideoModels, getModelById } from '@/constants/models'
 import { isCjkLocale } from '@/i18n/routing'
 
 import {
@@ -28,6 +36,17 @@ function formatDuration(seconds: number): string {
   const min = Math.floor(seconds / 60)
   const sec = seconds % 60
   return min > 0 ? `${min}:${String(sec).padStart(2, '0')}` : `${sec}s`
+}
+
+const RESOLUTION_OPTIONS = ['480p', '720p', '1080p'] as const
+
+function loadImageAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
 }
 
 export default function VideoGenerateForm() {
@@ -54,6 +73,12 @@ export default function VideoGenerateForm() {
   const [aspectRatio, setAspectRatio] = useState<string>(
     VIDEO_GENERATION.DEFAULT_ASPECT_RATIO,
   )
+  const [referenceImage, setReferenceImage] = useState<string | undefined>()
+  const [resolution, setResolution] = useState<string | undefined>()
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [negativePrompt, setNegativePrompt] = useState('')
+  const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const videoModels = getAvailableVideoModels()
 
@@ -87,6 +112,25 @@ export default function VideoGenerateForm() {
     modelOptions.find((o) => o.optionId === selectedOptionId) ?? modelOptions[0]
 
   const selectedApiKeyId = selectedModel?.keyId
+  const selectedModelConfig = selectedModel
+    ? getModelById(selectedModel.modelId)
+    : undefined
+
+  const handleFileChange = useCallback(async (file: File) => {
+    if (!file.type.startsWith('image/')) return
+    const base64 = await loadImageAsBase64(file)
+    setReferenceImage(base64)
+  }, [])
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      setIsDragging(false)
+      const file = e.dataTransfer.files[0]
+      if (file) await handleFileChange(file)
+    },
+    [handleFileChange],
+  )
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -98,10 +142,28 @@ export default function VideoGenerateForm() {
         modelId: selectedModel.modelId,
         aspectRatio: aspectRatio as '1:1' | '16:9' | '9:16' | '4:3' | '3:4',
         duration,
+        referenceImage,
+        negativePrompt: negativePrompt.trim() || undefined,
+        resolution: resolution as
+          | '480p'
+          | '540p'
+          | '720p'
+          | '1080p'
+          | undefined,
         apiKeyId: selectedApiKeyId,
       })
     },
-    [selectedModel, prompt, aspectRatio, duration, selectedApiKeyId, generate],
+    [
+      selectedModel,
+      prompt,
+      aspectRatio,
+      duration,
+      referenceImage,
+      negativePrompt,
+      resolution,
+      selectedApiKeyId,
+      generate,
+    ],
   )
 
   const stageLabels: Record<string, string> = {
@@ -110,18 +172,30 @@ export default function VideoGenerateForm() {
     uploading: t('stageUploading'),
   }
 
+  const tierLabel = selectedModelConfig?.qualityTier
+
   return (
     <form onSubmit={handleSubmit} className="space-y-5">
       {/* Model Selector */}
       <div className="rounded-3xl border border-border/75 bg-card/82 p-5 sm:p-6">
-        <label
-          className={cn(
-            'mb-3 block text-xs font-semibold text-muted-foreground',
-            !cjk && 'uppercase tracking-nav',
+        <div className="mb-3 flex items-center gap-2">
+          <label
+            className={cn(
+              'text-xs font-semibold text-muted-foreground',
+              !cjk && 'uppercase tracking-nav',
+            )}
+          >
+            {t('modelLabel')}
+          </label>
+          {tierLabel && (
+            <Badge
+              variant={tierLabel === 'premium' ? 'default' : 'secondary'}
+              className="rounded-full px-2 py-0.5 text-[10px]"
+            >
+              {tierLabel}
+            </Badge>
           )}
-        >
-          {t('modelLabel')}
-        </label>
+        </div>
         <ModelSelector
           options={modelOptions}
           value={selectedModel?.optionId ?? ''}
@@ -129,8 +203,8 @@ export default function VideoGenerateForm() {
         />
       </div>
 
-      {/* Duration + Aspect Ratio */}
-      <div className="grid gap-4 sm:grid-cols-2">
+      {/* Duration + Aspect Ratio + Resolution */}
+      <div className="grid gap-4 sm:grid-cols-3">
         <div className="rounded-3xl border border-border/75 bg-card/82 p-5">
           <label
             className={cn(
@@ -186,6 +260,112 @@ export default function VideoGenerateForm() {
             ))}
           </div>
         </div>
+
+        <div className="rounded-3xl border border-border/75 bg-card/82 p-5">
+          <label
+            className={cn(
+              'mb-3 block text-xs font-semibold text-muted-foreground',
+              !cjk && 'uppercase tracking-nav',
+            )}
+          >
+            {t('resolutionLabel')}
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {RESOLUTION_OPTIONS.map((r) => (
+              <button
+                key={r}
+                type="button"
+                onClick={() => setResolution(resolution === r ? undefined : r)}
+                className={cn(
+                  'rounded-full px-4 py-2 text-sm font-medium transition-colors',
+                  resolution === r
+                    ? 'bg-foreground text-background'
+                    : 'border border-border/75 bg-background/50 text-foreground hover:bg-muted/30',
+                )}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Reference Image */}
+      <div className="rounded-3xl border border-border/75 bg-card/82 p-5 sm:p-6">
+        <div className="mb-3 flex items-center justify-between">
+          <label
+            className={cn(
+              'text-xs font-semibold text-muted-foreground',
+              !cjk && 'uppercase tracking-nav',
+            )}
+          >
+            {t('referenceImageLabel')}
+          </label>
+          {referenceImage && (
+            <Badge variant="secondary" className="rounded-full px-2 py-0.5">
+              I2V
+            </Badge>
+          )}
+        </div>
+
+        {referenceImage ? (
+          <div className="relative inline-flex overflow-hidden rounded-2xl border border-border/75 bg-background">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={referenceImage}
+              alt={t('referenceImageLabel')}
+              className="h-36 w-auto object-cover"
+            />
+            <button
+              type="button"
+              onClick={() => setReferenceImage(undefined)}
+              className="absolute right-3 top-3 rounded-full border border-border/75 bg-background/92 p-1.5 text-muted-foreground transition-colors hover:text-destructive"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+        ) : (
+          <div
+            role="button"
+            tabIndex={0}
+            onDragOver={(e) => {
+              e.preventDefault()
+              setIsDragging(true)
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={handleDrop}
+            onClick={() => fileInputRef.current?.click()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                fileInputRef.current?.click()
+              }
+            }}
+            className={cn(
+              'flex cursor-pointer flex-col items-center gap-2 rounded-2xl border-2 border-dashed px-6 py-8 text-center transition-colors',
+              isDragging
+                ? 'border-primary/60 bg-primary/5'
+                : 'border-border/80 bg-background/72 hover:border-primary/40 hover:bg-secondary/18',
+            )}
+          >
+            <Upload className="size-5 text-muted-foreground" />
+            <p className="text-sm font-medium text-foreground">
+              {t('referenceImageUpload')}
+            </p>
+            <p className="font-serif text-xs text-muted-foreground">
+              {t('referenceImageHint')}
+            </p>
+          </div>
+        )}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={async (e) => {
+            const file = e.target.files?.[0]
+            if (file) await handleFileChange(file)
+          }}
+        />
       </div>
 
       {/* Prompt */}
@@ -211,6 +391,44 @@ export default function VideoGenerateForm() {
           rows={4}
           className="min-h-28 rounded-3xl border-border/75 bg-background/72"
         />
+      </div>
+
+      {/* Advanced Settings */}
+      <div className="rounded-3xl border border-border/75 bg-card/82 p-5 sm:p-6">
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          className="flex w-full items-center justify-between"
+        >
+          <span
+            className={cn(
+              'text-xs font-semibold text-muted-foreground',
+              !cjk && 'uppercase tracking-nav',
+            )}
+          >
+            {t('advancedSettings')}
+          </span>
+          {showAdvanced ? (
+            <ChevronUp className="size-4 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="size-4 text-muted-foreground" />
+          )}
+        </button>
+
+        {showAdvanced && (
+          <div className="mt-4 border-t border-border/70 pt-4">
+            <label className="mb-2 block text-xs text-muted-foreground">
+              {t('negativePromptLabel')}
+            </label>
+            <Textarea
+              value={negativePrompt}
+              onChange={(e) => setNegativePrompt(e.target.value)}
+              placeholder={t('negativePromptPlaceholder')}
+              rows={2}
+              className="min-h-16 rounded-2xl border-border/75 bg-background/72 text-sm"
+            />
+          </div>
+        )}
       </div>
 
       {/* Submit */}

--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -23,10 +23,13 @@ export enum AI_MODELS {
   IDEOGRAM_2 = 'ideogram-2',
   // Video models
   KLING_VIDEO = 'kling-video',
+  KLING_V3_PRO = 'kling-v3-pro',
   MINIMAX_VIDEO = 'minimax-video',
   LUMA_RAY_2 = 'luma-ray-2',
   WAN_VIDEO = 'wan-video',
   HUNYUAN_VIDEO = 'hunyuan-video',
+  SEEDANCE_PRO = 'seedance-pro',
+  VEO_3 = 'veo-3',
 }
 
 export const MODEL_MESSAGE_KEYS = {
@@ -40,11 +43,26 @@ export const MODEL_MESSAGE_KEYS = {
   [AI_MODELS.GEMINI_PRO_IMAGE]: 'geminiProImage',
   [AI_MODELS.IDEOGRAM_2]: 'ideogram2',
   [AI_MODELS.KLING_VIDEO]: 'klingVideo',
+  [AI_MODELS.KLING_V3_PRO]: 'klingV3Pro',
   [AI_MODELS.MINIMAX_VIDEO]: 'minimaxVideo',
   [AI_MODELS.LUMA_RAY_2]: 'lumaRay2',
   [AI_MODELS.WAN_VIDEO]: 'wanVideo',
   [AI_MODELS.HUNYUAN_VIDEO]: 'hunyuanVideo',
+  [AI_MODELS.SEEDANCE_PRO]: 'seedancePro',
+  [AI_MODELS.VEO_3]: 'veo3',
 } as const
+
+/** Quality tier for video models */
+export type QualityTier = 'budget' | 'standard' | 'premium'
+
+/** Model-specific default parameters for video generation */
+export interface VideoDefaults {
+  negativePrompt?: string
+  resolution?: string
+  cfgScale?: number
+  enablePromptOptimizer?: boolean
+  generateAudio?: boolean
+}
 
 /** Model option configuration */
 export interface ModelOption {
@@ -64,6 +82,12 @@ export interface ModelOption {
   available: boolean
   /** Provider polling timeout in ms (video models need longer) */
   timeoutMs?: number
+  /** Quality tier (video models) */
+  qualityTier?: QualityTier
+  /** Image-to-Video endpoint (when different from T2V endpoint) */
+  i2vModelId?: string
+  /** Model-specific default parameters for video */
+  videoDefaults?: VideoDefaults
 }
 
 /** All model options with their configuration */
@@ -149,7 +173,53 @@ export const MODEL_OPTIONS: ModelOption[] = [
     outputType: 'IMAGE',
     available: true,
   },
-  // Video models
+  // ─── Video models (Premium) ─────────────────────────────────────
+  {
+    id: AI_MODELS.VEO_3,
+    cost: 8,
+    adapterType: AI_ADAPTER_TYPES.FAL,
+    providerConfig: getDefaultProviderConfig(AI_ADAPTER_TYPES.FAL),
+    externalModelId: 'fal-ai/veo3',
+    outputType: 'VIDEO',
+    available: true,
+    timeoutMs: 300_000,
+    qualityTier: 'premium',
+    i2vModelId: 'fal-ai/veo3/image-to-video',
+    videoDefaults: {
+      resolution: '1080p',
+      generateAudio: true,
+    },
+  },
+  {
+    id: AI_MODELS.KLING_V3_PRO,
+    cost: 6,
+    adapterType: AI_ADAPTER_TYPES.FAL,
+    providerConfig: getDefaultProviderConfig(AI_ADAPTER_TYPES.FAL),
+    externalModelId: 'fal-ai/kling-video/v3/pro/text-to-video',
+    outputType: 'VIDEO',
+    available: true,
+    timeoutMs: 300_000,
+    qualityTier: 'premium',
+    i2vModelId: 'fal-ai/kling-video/v3/pro/image-to-video',
+    videoDefaults: {
+      negativePrompt: 'blur, distort, and low quality',
+      cfgScale: 0.5,
+      generateAudio: true,
+    },
+  },
+  // ─── Video models (Standard) ──────────────────────────────────
+  {
+    id: AI_MODELS.SEEDANCE_PRO,
+    cost: 4,
+    adapterType: AI_ADAPTER_TYPES.FAL,
+    providerConfig: getDefaultProviderConfig(AI_ADAPTER_TYPES.FAL),
+    externalModelId: 'fal-ai/bytedance/seedance/v1/pro/text-to-video',
+    outputType: 'VIDEO',
+    available: true,
+    timeoutMs: 300_000,
+    qualityTier: 'standard',
+    i2vModelId: 'fal-ai/bytedance/seedance/v1/pro/image-to-video',
+  },
   {
     id: AI_MODELS.KLING_VIDEO,
     cost: 5,
@@ -159,6 +229,12 @@ export const MODEL_OPTIONS: ModelOption[] = [
     outputType: 'VIDEO',
     available: true,
     timeoutMs: 300_000,
+    qualityTier: 'standard',
+    i2vModelId: 'fal-ai/kling-video/v2/master/image-to-video',
+    videoDefaults: {
+      negativePrompt: 'blur, distort, and low quality',
+      cfgScale: 0.5,
+    },
   },
   {
     id: AI_MODELS.MINIMAX_VIDEO,
@@ -169,6 +245,11 @@ export const MODEL_OPTIONS: ModelOption[] = [
     outputType: 'VIDEO',
     available: true,
     timeoutMs: 180_000,
+    qualityTier: 'standard',
+    i2vModelId: 'fal-ai/minimax-video/video-01/image-to-video',
+    videoDefaults: {
+      enablePromptOptimizer: true,
+    },
   },
   {
     id: AI_MODELS.LUMA_RAY_2,
@@ -179,7 +260,12 @@ export const MODEL_OPTIONS: ModelOption[] = [
     outputType: 'VIDEO',
     available: true,
     timeoutMs: 120_000,
+    qualityTier: 'standard',
+    videoDefaults: {
+      resolution: '720p',
+    },
   },
+  // ─── Video models (Budget) ────────────────────────────────────
   {
     id: AI_MODELS.WAN_VIDEO,
     cost: 2,
@@ -189,6 +275,12 @@ export const MODEL_OPTIONS: ModelOption[] = [
     outputType: 'VIDEO',
     available: true,
     timeoutMs: 180_000,
+    qualityTier: 'budget',
+    videoDefaults: {
+      negativePrompt:
+        'bright colors, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards',
+      resolution: '720p',
+    },
   },
   {
     id: AI_MODELS.HUNYUAN_VIDEO,
@@ -199,6 +291,11 @@ export const MODEL_OPTIONS: ModelOption[] = [
     outputType: 'VIDEO',
     available: true,
     timeoutMs: 300_000,
+    qualityTier: 'budget',
+    i2vModelId: 'fal-ai/hunyuan-video-image-to-video',
+    videoDefaults: {
+      resolution: '720p',
+    },
   },
 ]
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -204,6 +204,13 @@
     "generatingTitle": "Generating your video...",
     "elapsed": "Elapsed: {seconds}",
     "resultLabel": "Result",
+    "referenceImageLabel": "Reference Image (I2V)",
+    "referenceImageUpload": "Upload an image to animate",
+    "referenceImageHint": "PNG, JPG — drag & drop or click",
+    "resolutionLabel": "Resolution",
+    "advancedSettings": "Advanced Settings",
+    "negativePromptLabel": "Negative Prompt",
+    "negativePromptPlaceholder": "Describe what to avoid in the video...",
     "errorFallback": "Video generation failed. Please try again.",
     "errorUnexpected": "An unexpected error occurred.",
     "errorTimeout": "Video generation timed out. Please try again."
@@ -617,25 +624,37 @@
       "label": "Ideogram 2.0",
       "description": "Exceptional at rendering text in images with strong artistic quality."
     },
+    "veo3": {
+      "label": "Veo 3",
+      "description": "Google's flagship — 4K, native audio, dialogue sync"
+    },
+    "klingV3Pro": {
+      "label": "Kling 3.0 Pro",
+      "description": "Top-tier cinematic video, 15s, native audio, 1080p"
+    },
+    "seedancePro": {
+      "label": "Seedance Pro",
+      "description": "ByteDance — native audio, cinematic camera controls"
+    },
     "klingVideo": {
-      "label": "Kling Video",
-      "description": "High-quality cinematic video generation"
+      "label": "Kling V2",
+      "description": "Reliable cinematic video, motion-aware, I2V support"
     },
     "minimaxVideo": {
       "label": "MiniMax Video",
-      "description": "Fast video generation with good quality"
+      "description": "Fast generation with prompt optimizer, camera controls"
     },
     "lumaRay2": {
       "label": "Luma Ray 2",
-      "description": "Creative and artistic video generation"
+      "description": "Up to 1080p, loop support, dual-image interpolation"
     },
     "wanVideo": {
       "label": "Wan Video",
-      "description": "Open-source video model with great value"
+      "description": "Budget-friendly open-source, 720p, great value"
     },
     "hunyuanVideo": {
       "label": "Hunyuan Video",
-      "description": "Powerful video generation by Tencent"
+      "description": "Tencent open-source, 8.3B params, 720p, I2V support"
     }
   }
 }

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -204,6 +204,13 @@
     "generatingTitle": "動画を生成中...",
     "elapsed": "経過時間: {seconds}",
     "resultLabel": "結果",
+    "referenceImageLabel": "参照画像（I2V）",
+    "referenceImageUpload": "アニメーションする画像をアップロード",
+    "referenceImageHint": "PNG、JPG — ドラッグ＆ドロップまたはクリック",
+    "resolutionLabel": "解像度",
+    "advancedSettings": "詳細設定",
+    "negativePromptLabel": "ネガティブプロンプト",
+    "negativePromptPlaceholder": "動画で避けたい要素を記述...",
     "errorFallback": "動画生成に失敗しました。もう一度お試しください。",
     "errorUnexpected": "予期しないエラーが発生しました。",
     "errorTimeout": "動画生成がタイムアウトしました。もう一度お試しください。"
@@ -617,25 +624,37 @@
       "label": "Ideogram 2.0",
       "description": "画像内テキスト描画に優れた高品質アートモデル。"
     },
+    "veo3": {
+      "label": "Veo 3",
+      "description": "Google最新 — 4K、ネイティブ音声、対話同期"
+    },
+    "klingV3Pro": {
+      "label": "Kling 3.0 Pro",
+      "description": "最高品質シネマティック、15秒、音声付き、1080p"
+    },
+    "seedancePro": {
+      "label": "Seedance Pro",
+      "description": "ByteDance — 音声付き、映画的カメラコントロール"
+    },
     "klingVideo": {
-      "label": "Kling Video",
-      "description": "高品質な映画的動画生成"
+      "label": "Kling V2",
+      "description": "安定した映画的動画、モーション対応、I2V対応"
     },
     "minimaxVideo": {
       "label": "MiniMax Video",
-      "description": "高品質な高速動画生成"
+      "description": "高速生成、プロンプト最適化、カメラ制御"
     },
     "lumaRay2": {
       "label": "Luma Ray 2",
-      "description": "クリエイティブな芸術的動画生成"
+      "description": "最大1080p、ループ対応、二画像補間"
     },
     "wanVideo": {
       "label": "Wan Video",
-      "description": "高コスパのオープンソース動画モデル"
+      "description": "高コスパのオープンソース、720p"
     },
     "hunyuanVideo": {
       "label": "Hunyuan Video",
-      "description": "テンセントによる強力な動画生成"
+      "description": "テンセントオープンソース、8.3Bパラメータ、I2V対応"
     }
   }
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -204,6 +204,13 @@
     "generatingTitle": "正在生成视频...",
     "elapsed": "已等待 {seconds}",
     "resultLabel": "结果",
+    "referenceImageLabel": "参照图片（图生视频）",
+    "referenceImageUpload": "上传图片生成视频",
+    "referenceImageHint": "PNG、JPG — 拖拽或点击上传",
+    "resolutionLabel": "分辨率",
+    "advancedSettings": "高级设置",
+    "negativePromptLabel": "反向提示词",
+    "negativePromptPlaceholder": "描述视频中要避免的元素...",
     "errorFallback": "视频生成失败，请重试。",
     "errorUnexpected": "发生了意外错误。",
     "errorTimeout": "视频生成超时，请重试。"
@@ -617,25 +624,37 @@
       "label": "Ideogram 2.0",
       "description": "擅长在图像中渲染文字，兼具出色的艺术质感。"
     },
+    "veo3": {
+      "label": "Veo 3",
+      "description": "Google 旗舰 — 4K、原生音频、对话同步"
+    },
+    "klingV3Pro": {
+      "label": "可灵 3.0 Pro",
+      "description": "顶级电影画质，15秒、原生音频、1080p"
+    },
+    "seedancePro": {
+      "label": "Seedance Pro",
+      "description": "字节跳动 — 原生音频、电影级镜头控制"
+    },
     "klingVideo": {
-      "label": "可灵视频",
-      "description": "高质量电影级视频生成"
+      "label": "可灵 V2",
+      "description": "稳定的电影级视频，运动感知，支持图生视频"
     },
     "minimaxVideo": {
       "label": "MiniMax 视频",
-      "description": "快速高质量视频生成"
+      "description": "快速生成，提示词优化，镜头控制"
     },
     "lumaRay2": {
       "label": "Luma Ray 2",
-      "description": "创意艺术视频生成"
+      "description": "最高1080p，循环视频，双图插值"
     },
     "wanVideo": {
       "label": "万象视频",
-      "description": "高性价比开源视频模型"
+      "description": "超高性价比开源模型，720p"
     },
     "hunyuanVideo": {
       "label": "混元视频",
-      "description": "腾讯混元视频生成"
+      "description": "腾讯开源，83亿参数，支持图生视频"
     }
   }
 }

--- a/src/services/generate-video.service.ts
+++ b/src/services/generate-video.service.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import { API_USAGE } from '@/constants/config'
-import { getModelById, getModelTimeout } from '@/constants/models'
+import { getModelById } from '@/constants/models'
 import { getProviderLabel } from '@/constants/providers'
 import type {
   GenerateVideoRequest,
@@ -52,6 +52,8 @@ export async function submitVideoGeneration(
     )
   }
 
+  const modelConfig = getModelById(executionRoute.modelId)
+
   const queueResult = await providerAdapter.submitVideoToQueue({
     prompt: input.prompt,
     modelId: executionRoute.modelId,
@@ -60,6 +62,10 @@ export async function submitVideoGeneration(
     apiKey: executionRoute.apiKey,
     duration: input.duration,
     referenceImage: input.referenceImage,
+    negativePrompt: input.negativePrompt,
+    resolution: input.resolution,
+    i2vModelId: modelConfig?.i2vModelId,
+    videoDefaults: modelConfig?.videoDefaults as Record<string, unknown>,
   })
 
   const generationJob = await createGenerationJob({

--- a/src/services/providers/fal.adapter.ts
+++ b/src/services/providers/fal.adapter.ts
@@ -193,9 +193,17 @@ export const falAdapter: ProviderAdapter = {
     apiKey,
     duration,
     referenceImage,
+    negativePrompt,
+    resolution,
+    i2vModelId,
+    videoDefaults,
   }: ProviderQueueSubmitInput) {
     const externalModelId = getExecutionModelId(modelId)
-    const endpoint = `${AI_PROVIDER_ENDPOINTS.FAL_QUEUE}/${externalModelId}`
+
+    // Use I2V endpoint when reference image is provided and model has a dedicated I2V endpoint
+    const effectiveModelId =
+      referenceImage && i2vModelId ? i2vModelId : externalModelId
+    const endpoint = `${AI_PROVIDER_ENDPOINTS.FAL_QUEUE}/${effectiveModelId}`
 
     const body: Record<string, unknown> = {
       prompt,
@@ -203,8 +211,34 @@ export const falAdapter: ProviderAdapter = {
       duration: String(duration ?? VIDEO_GENERATION.DEFAULT_DURATION),
     }
 
+    // Reference image for I2V
     if (referenceImage) {
       body.image_url = referenceImage
+    }
+
+    // Apply model-specific defaults first, then user overrides
+    if (videoDefaults?.negativePrompt) {
+      body.negative_prompt = videoDefaults.negativePrompt
+    }
+    if (videoDefaults?.cfgScale !== undefined) {
+      body.cfg_scale = videoDefaults.cfgScale
+    }
+    if (videoDefaults?.enablePromptOptimizer !== undefined) {
+      body.prompt_optimizer = videoDefaults.enablePromptOptimizer
+    }
+    if (videoDefaults?.generateAudio !== undefined) {
+      body.generate_audio = videoDefaults.generateAudio
+    }
+    if (videoDefaults?.resolution) {
+      body.resolution = videoDefaults.resolution
+    }
+
+    // User overrides
+    if (negativePrompt) {
+      body.negative_prompt = negativePrompt
+    }
+    if (resolution) {
+      body.resolution = resolution
     }
 
     const response = await fetch(endpoint, {

--- a/src/services/providers/types.ts
+++ b/src/services/providers/types.ts
@@ -45,6 +45,10 @@ export interface ProviderQueueSubmitInput {
   apiKey: string
   duration?: number
   referenceImage?: string
+  negativePrompt?: string
+  resolution?: string
+  i2vModelId?: string
+  videoDefaults?: Record<string, unknown>
 }
 
 export interface ProviderQueueSubmitResult {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,6 +75,8 @@ export const GenerateVideoRequestSchema = z.object({
     .max(VIDEO_GENERATION.MAX_DURATION)
     .default(VIDEO_GENERATION.DEFAULT_DURATION),
   referenceImage: z.string().optional(),
+  negativePrompt: z.string().trim().max(2000).optional(),
+  resolution: z.enum(['480p', '540p', '720p', '1080p']).optional(),
   apiKeyId: z.string().trim().min(1).optional(),
 })
 


### PR DESCRIPTION
New models:
- Veo 3 (Google, 4K, native audio, $0.40/s)
- Kling 3.0 Pro (15s, native audio, 1080p)
- Seedance Pro (ByteDance, cinematic camera controls)

Enhancements:
- Image-to-Video (I2V): upload reference image with auto I2V endpoint switching for models with dedicated I2V endpoints
- Resolution selector (480p/720p/1080p)
- Negative prompt support in advanced settings
- Model-specific defaults (cfg_scale, prompt_optimizer, etc.)
- Quality tier badges (budget/standard/premium) on model selector
- Updated model descriptions with specific features (en/ja/zh)