### PR TITLE
fix: arena bugs — reference image, model filtering, API key binding, …

### DIFF
--- a/src/app/api/arena/matches/[id]/vote/route.ts
+++ b/src/app/api/arena/matches/[id]/vote/route.ts
@@ -53,9 +53,18 @@ export async function POST(
       data: result,
     })
   } catch (error) {
-    console.error('[API /api/arena/matches/[id]/vote] Error:', error)
     const message =
       error instanceof Error ? error.message : 'An unexpected error occurred'
+
+    // Already voted is not a server error — return 409 Conflict
+    if (message === 'Match already voted') {
+      return NextResponse.json<ArenaVoteResponse>(
+        { success: false, error: message },
+        { status: 409 },
+      )
+    }
+
+    console.error('[API /api/arena/matches/[id]/vote] Error:', error)
     return NextResponse.json<ArenaVoteResponse>(
       { success: false, error: message },
       { status: 500 },

--- a/src/app/api/arena/matches/route.ts
+++ b/src/app/api/arena/matches/route.ts
@@ -3,6 +3,9 @@ import { auth } from '@clerk/nextjs/server'
 import { CreateArenaMatchRequestSchema } from '@/types'
 
 export const maxDuration = 55
+
+// Allow large reference images (base64): 10MB image ≈ ~14MB JSON string
+export const bodySizeLimit = '15mb'
 import type { CreateArenaMatchResponse, ArenaMatchResponse } from '@/types'
 import { createArenaMatch, getArenaMatch } from '@/services/arena.service'
 import { rateLimit } from '@/lib/rate-limit'

--- a/src/app/api/image/analyze/[id]/variations/route.ts
+++ b/src/app/api/image/analyze/[id]/variations/route.ts
@@ -58,7 +58,7 @@ export async function POST(
     const result = await generateVariations(
       clerkId,
       id,
-      parseResult.data.modelIds,
+      parseResult.data.models,
       parseResult.data.aspectRatio,
     )
 

--- a/src/components/business/ArenaForm.tsx
+++ b/src/components/business/ArenaForm.tsx
@@ -19,6 +19,7 @@ import {
   type AspectRatio,
 } from '@/constants/config'
 import {
+  getModelById,
   getModelMessageKey,
   isBuiltInModel,
   MODEL_OPTIONS,
@@ -105,7 +106,13 @@ function buildModelOptions(
     }
   })
 
-  const savedOptions: ArenaModelOption[] = activeApiKeys.map((key) => ({
+  // Only include saved keys for image models in arena
+  const imageApiKeys = activeApiKeys.filter((key) => {
+    const model = getModelById(key.modelId)
+    return !model || model.outputType === 'IMAGE'
+  })
+
+  const savedOptions: ArenaModelOption[] = imageApiKeys.map((key) => ({
     optionId: `key:${key.id}`,
     modelId: key.modelId,
     adapterType: key.adapterType as StudioModelOption['adapterType'],
@@ -120,7 +127,17 @@ function buildModelOptions(
     keyStatus: healthToKeyStatus(healthMap[key.id]),
   }))
 
-  return [...builtInOptions, ...savedOptions]
+  // Sort: ready first, then nokey, then unavailable
+  const STATUS_SORT_ORDER: Record<ModelKeyStatus, number> = {
+    ready: 0,
+    nokey: 1,
+    unavailable: 2,
+  }
+  const all = [...builtInOptions, ...savedOptions]
+  all.sort(
+    (a, b) => STATUS_SORT_ORDER[a.keyStatus] - STATUS_SORT_ORDER[b.keyStatus],
+  )
+  return all
 }
 
 const STATUS_DOT_CLASSES: Record<ModelKeyStatus, string> = {
@@ -159,21 +176,19 @@ export function ArenaForm({ isCreating, onBattle }: ArenaFormProps) {
     [apiKeys, healthMap],
   )
 
-  // Deselect models whose key verification failed
+  // Deselect models that are not ready (only green/ready models can be selected)
   useEffect(() => {
     setSelectedOptionIds((prev) => {
-      const unavailableIds = new Set(
+      const notReadyIds = new Set(
         modelOptions
-          .filter(
-            (opt) => opt.keyStatus !== 'ready' && opt.keyStatus !== 'nokey',
-          )
+          .filter((opt) => opt.keyStatus !== 'ready')
           .map((opt) => opt.optionId),
       )
-      if (unavailableIds.size === 0) return prev
+      if (notReadyIds.size === 0) return prev
 
       const next = new Set<string>()
       for (const id of prev) {
-        if (!unavailableIds.has(id)) {
+        if (!notReadyIds.has(id)) {
           next.add(id)
         }
       }
@@ -185,12 +200,7 @@ export function ArenaForm({ isCreating, onBattle }: ArenaFormProps) {
   const [aspectRatio, setAspectRatio] =
     useState<AspectRatio>(DEFAULT_ASPECT_RATIO)
   const [selectedOptionIds, setSelectedOptionIds] = useState<Set<string>>(
-    () =>
-      new Set(
-        MODEL_OPTIONS.filter(
-          (m) => m.available && m.outputType === 'IMAGE',
-        ).map((m) => `workspace:${m.id}`),
-      ),
+    () => new Set(),
   )
   const [showModelPanel, setShowModelPanel] = useState(false)
   const [referenceImage, setReferenceImage] = useState<string | undefined>()
@@ -305,10 +315,10 @@ export function ArenaForm({ isCreating, onBattle }: ArenaFormProps) {
                   key={option.optionId}
                   type="button"
                   onClick={() => toggleModel(option.optionId)}
-                  disabled={isCreating || option.keyStatus === 'unavailable'}
+                  disabled={isCreating || option.keyStatus !== 'ready'}
                   className={cn(
                     'flex items-center gap-3 rounded-2xl border px-4 py-3 text-left transition-all',
-                    option.keyStatus === 'unavailable' &&
+                    option.keyStatus !== 'ready' &&
                       'cursor-not-allowed opacity-50',
                     isSelected
                       ? 'border-primary/60 bg-primary/5 ring-1 ring-primary/20'
@@ -543,6 +553,7 @@ export function ArenaForm({ isCreating, onBattle }: ArenaFormProps) {
           <div className="mt-4 border-t border-border/70 pt-4">
             <ReverseEngineerPanel
               onUsePrompt={(generatedPrompt) => setPrompt(generatedPrompt)}
+              selectedModels={selectedModels}
             />
           </div>
         )}

--- a/src/components/business/GenerateForm.tsx
+++ b/src/components/business/GenerateForm.tsx
@@ -523,7 +523,18 @@ export function GenerateForm() {
 
           {/* Reverse Engineer Panel */}
           <div className="mt-5 rounded-3xl border border-border/70 bg-background/46 p-4">
-            <ReverseEngineerPanel />
+            <ReverseEngineerPanel
+              selectedModels={
+                selectedModel
+                  ? [
+                      {
+                        modelId: selectedModel.modelId,
+                        apiKeyId: selectedModel.keyId,
+                      },
+                    ]
+                  : undefined
+              }
+            />
           </div>
         </section>
       </div>

--- a/src/components/business/ReverseEngineerPanel.tsx
+++ b/src/components/business/ReverseEngineerPanel.tsx
@@ -12,7 +12,7 @@ import {
 import { useTranslations } from 'next-intl'
 
 import { DEFAULT_ASPECT_RATIO, type AspectRatio } from '@/constants/config'
-import { getAvailableModels } from '@/constants/models'
+import type { GenerateVariationsModel } from '@/types'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { VariationGrid } from '@/components/business/VariationGrid'
@@ -51,10 +51,13 @@ function resizeImageToBase64(file: File): Promise<string> {
 
 interface ReverseEngineerPanelProps {
   onUsePrompt?: (prompt: string) => void
+  /** Selected models with their bound API keys from the parent page */
+  selectedModels?: GenerateVariationsModel[]
 }
 
 export function ReverseEngineerPanel({
   onUsePrompt,
+  selectedModels,
 }: ReverseEngineerPanelProps = {}) {
   const t = useTranslations('ReverseEngineer')
   const {
@@ -105,12 +108,9 @@ export function ReverseEngineerPanel({
   )
 
   const handleGenerateAll = useCallback(() => {
-    const models = getAvailableModels()
-    generateVariations(
-      models.map((m) => m.id),
-      aspectRatio,
-    )
-  }, [generateVariations, aspectRatio])
+    if (!selectedModels || selectedModels.length === 0) return
+    generateVariations(selectedModels, aspectRatio)
+  }, [generateVariations, aspectRatio, selectedModels])
 
   const handleReset = useCallback(() => {
     setPreviewUrl(null)

--- a/src/constants/models.ts
+++ b/src/constants/models.ts
@@ -121,7 +121,7 @@ export const MODEL_OPTIONS: ModelOption[] = [
     cost: 3,
     adapterType: AI_ADAPTER_TYPES.GEMINI,
     providerConfig: getDefaultProviderConfig(AI_ADAPTER_TYPES.GEMINI),
-    externalModelId: 'gemini-3.1-pro-image-preview',
+    externalModelId: 'gemini-3-pro-image-preview',
     outputType: 'IMAGE',
     available: true,
     officialUrl: 'https://ai.google.dev/gemini-api/docs/models/gemini-v3',

--- a/src/hooks/use-arena.ts
+++ b/src/hooks/use-arena.ts
@@ -97,7 +97,10 @@ export function useArena() {
 
   const vote = useCallback(
     async (winnerEntryId: string) => {
-      if (!state.matchId) return
+      if (!state.matchId || state.step !== 'voting') return
+
+      // Optimistically move to revealed to prevent double-click
+      setState((prev) => ({ ...prev, step: 'revealed' }))
 
       const result = await submitArenaVoteAPI(state.matchId, {
         winnerEntryId,
@@ -116,11 +119,12 @@ export function useArena() {
       } else {
         setState((prev) => ({
           ...prev,
+          step: 'voting',
           error: result.error ?? 'Vote failed',
         }))
       }
     },
-    [state.matchId],
+    [state.matchId, state.step],
   )
 
   const reset = useCallback(() => {

--- a/src/hooks/use-reverse-image.ts
+++ b/src/hooks/use-reverse-image.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from 'react'
 import type { AspectRatio } from '@/constants/config'
-import type { GenerationRecord } from '@/types'
+import type { GenerationRecord, GenerateVariationsModel } from '@/types'
 import { analyzeImageAPI, generateVariationsAPI } from '@/lib/api-client'
 
 type ReverseStep =
@@ -72,7 +72,7 @@ export function useReverseImage() {
   }, [])
 
   const generateVariations = useCallback(
-    async (modelIds: string[], aspectRatio: AspectRatio) => {
+    async (models: GenerateVariationsModel[], aspectRatio: AspectRatio) => {
       if (!state.analysisId) return
 
       setState((prev) => ({
@@ -82,7 +82,7 @@ export function useReverseImage() {
       }))
 
       const result = await generateVariationsAPI(state.analysisId, {
-        modelIds,
+        models,
         aspectRatio,
       })
 

--- a/src/services/arena.service.ts
+++ b/src/services/arena.service.ts
@@ -35,7 +35,9 @@ export async function createArenaMatch(
   if (input.models && input.models.length >= ARENA.MIN_MODELS_FOR_MATCH) {
     selectedModels = input.models
   } else {
-    const available = getAvailableModels()
+    const available = getAvailableModels().filter(
+      (m) => m.outputType === 'IMAGE',
+    )
     if (available.length < ARENA.MIN_MODELS_FOR_MATCH) {
       throw new Error(
         `Arena requires at least ${ARENA.MIN_MODELS_FOR_MATCH} available models`,

--- a/src/services/image-analysis.service.ts
+++ b/src/services/image-analysis.service.ts
@@ -2,7 +2,7 @@ import 'server-only'
 
 import { db } from '@/lib/db'
 import type { AspectRatio } from '@/constants/config'
-import type { GenerationRecord } from '@/types'
+import type { GenerationRecord, GenerateVariationsModel } from '@/types'
 import {
   llmTextCompletion,
   resolveLlmTextRoute,
@@ -89,7 +89,7 @@ export async function getAnalysisById(
 export async function generateVariations(
   clerkId: string,
   analysisId: string,
-  modelIds: string[],
+  models: GenerateVariationsModel[],
   aspectRatio: AspectRatio,
 ): Promise<{ variations: GenerationRecord[]; failed: string[] }> {
   const dbUser = await getUserByClerkId(clerkId)
@@ -104,11 +104,12 @@ export async function generateVariations(
   }
 
   const results = await Promise.allSettled(
-    modelIds.map((modelId) =>
+    models.map((model) =>
       generateImageForUser(clerkId, {
         prompt: analysis.generatedPrompt,
-        modelId,
+        modelId: model.modelId,
         aspectRatio,
+        apiKeyId: model.apiKeyId,
       }),
     ),
   )
@@ -120,7 +121,7 @@ export async function generateVariations(
     if (result.status === 'fulfilled') {
       variations.push(result.value)
     } else {
-      failed.push(modelIds[index])
+      failed.push(models[index].modelId)
     }
   })
 

--- a/src/services/providers/gemini.adapter.ts
+++ b/src/services/providers/gemini.adapter.ts
@@ -7,6 +7,7 @@ import {
   AI_PROVIDER_ENDPOINTS,
   IMAGE_SIZES,
 } from '@/constants/config'
+import { getExecutionModelId } from '@/constants/models'
 import { AI_ADAPTER_TYPES } from '@/constants/providers'
 import { fetchAsBuffer } from '@/services/storage/r2'
 
@@ -81,7 +82,7 @@ export const geminiAdapter: ProviderAdapter = {
   }: ProviderGenerationInput) {
     const { width, height } = IMAGE_SIZES[aspectRatio] ?? IMAGE_SIZES['1:1']
     const baseUrl = providerConfig.baseUrl || AI_PROVIDER_ENDPOINTS.GEMINI
-    const endpoint = `${baseUrl}/${modelId}:generateContent`
+    const endpoint = `${baseUrl}/${getExecutionModelId(modelId)}:generateContent`
     const parts: Array<Record<string, unknown>> = [{ text: prompt }]
 
     if (referenceImage) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -332,8 +332,17 @@ export interface AnalyzeImageResponse {
   error?: string
 }
 
+export const GenerateVariationsModelSchema = z.object({
+  modelId: z.string().trim().min(1),
+  apiKeyId: z.string().trim().min(1).optional(),
+})
+
+export type GenerateVariationsModel = z.infer<
+  typeof GenerateVariationsModelSchema
+>
+
 export const GenerateVariationsRequestSchema = z.object({
-  modelIds: z.array(z.string().trim().min(1)).min(1).max(9),
+  models: z.array(GenerateVariationsModelSchema).min(1).max(9),
   aspectRatio: z.enum(['1:1', '16:9', '9:16', '4:3', '3:4']).default('1:1'),
 })
 


### PR DESCRIPTION
…vote UX

- Add bodySizeLimit for arena API to allow base64 reference images
- Fix Gemini Pro model ID (gemini-3.1-pro → gemini-3-pro-image-preview)
- Fix Gemini adapter to use getExecutionModelId() for API calls
- Filter video models from arena model selection (frontend + backend)
- Sort models by key status: ready (green) first
- Default to no models selected on arena page load
- Only allow selecting models with ready (green) API keys
- Thread API key IDs through reverse engineer variations flow
- Prevent double-click on vote with optimistic step transition
- Return 409 instead of 500 for already-voted matches