### PR TITLE
fix: studio page mobile overflow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -304,6 +304,7 @@ html:lang(zh) {
   .editorial-panel {
     position: relative;
     overflow: hidden;
+    min-width: 0;
     padding: clamp(1.3rem, 2.5vw, 1.8rem);
     border: 1px solid var(--page-border);
     border-radius: var(--radius-3xl);

--- a/src/components/business/GenerateForm.tsx
+++ b/src/components/business/GenerateForm.tsx
@@ -196,14 +196,14 @@ export function GenerateForm() {
   return (
     <form onSubmit={handleSubmit} className="space-y-10">
       <div className="grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
-        <section className="rounded-3xl border border-border/75 bg-card/82 p-5 sm:p-6">
+        <section className="min-w-0 overflow-hidden rounded-3xl border border-border/75 bg-card/82 p-5 sm:p-6">
           <ModelSelector
             value={selectedModel.optionId}
             onChange={setSelectedOptionId}
             options={modelOptions}
           />
 
-          <div className="mt-6 rounded-3xl border border-border/70 bg-background/50 p-5">
+          <div className="mt-6 min-w-0 overflow-hidden rounded-3xl border border-border/70 bg-background/50 p-5">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="space-y-2">
                 <p
@@ -302,8 +302,8 @@ export function GenerateForm() {
                 )}
               </div>
 
-              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-                <div className="space-y-2 rounded-2xl border border-border/70 bg-secondary/18 px-3 py-3">
+              <div className="grid min-w-0 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <div className="min-w-0 space-y-2 rounded-2xl border border-border/70 bg-secondary/18 px-3 py-3">
                   <p
                     className={cn(
                       'text-[11px] font-semibold text-muted-foreground',
@@ -319,7 +319,7 @@ export function GenerateForm() {
                   </p>
                 </div>
 
-                <div className="space-y-2 rounded-2xl border border-border/70 bg-secondary/18 px-3 py-3">
+                <div className="min-w-0 space-y-2 rounded-2xl border border-border/70 bg-secondary/18 px-3 py-3">
                   <p
                     className={cn(
                       'text-[11px] font-semibold text-muted-foreground',
@@ -335,7 +335,7 @@ export function GenerateForm() {
                   </p>
                 </div>
 
-                <div className="space-y-2 rounded-2xl border border-border/70 bg-secondary/18 px-3 py-3 sm:col-span-2">
+                <div className="min-w-0 space-y-2 rounded-2xl border border-border/70 bg-secondary/18 px-3 py-3 sm:col-span-2">
                   <p
                     className={cn(
                       'text-[11px] font-semibold text-muted-foreground',
@@ -351,7 +351,7 @@ export function GenerateForm() {
                   </p>
                 </div>
 
-                <div className="space-y-2 rounded-2xl border border-border/70 bg-secondary/18 px-3 py-3 sm:col-span-2 xl:col-span-4">
+                <div className="min-w-0 space-y-2 rounded-2xl border border-border/70 bg-secondary/18 px-3 py-3 sm:col-span-2 xl:col-span-4">
                   <p
                     className={cn(
                       'text-[11px] font-semibold text-muted-foreground',
@@ -371,7 +371,7 @@ export function GenerateForm() {
           </div>
         </section>
 
-        <section className="rounded-3xl border border-border/75 bg-card/82 p-5 sm:p-6">
+        <section className="min-w-0 overflow-hidden rounded-3xl border border-border/75 bg-card/82 p-5 sm:p-6">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="space-y-1">
               <label

--- a/src/components/business/ModelSelector.tsx
+++ b/src/components/business/ModelSelector.tsx
@@ -78,7 +78,7 @@ export function ModelSelector({
       </div>
 
       <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="h-16 w-full rounded-3xl border-border/75 bg-background/72 px-4 text-left shadow-none">
+        <SelectTrigger className="h-16 w-full overflow-hidden rounded-3xl border-border/75 bg-background/72 px-4 text-left shadow-none">
           <SelectValue
             placeholder={t('placeholder')}
             aria-label={selectedOption?.modelId ?? t('placeholder')}
@@ -94,7 +94,7 @@ export function ModelSelector({
                     {t(`routeSources.${selectedOption.sourceType}`)}
                   </p>
                 </div>
-                <div className="flex shrink-0 items-center gap-2">
+                <div className="hidden items-center gap-2 sm:flex">
                   <Badge
                     variant={
                       selectedOption.sourceType === 'saved'

--- a/src/components/business/VideoGenerateForm.tsx
+++ b/src/components/business/VideoGenerateForm.tsx
@@ -258,7 +258,7 @@ export default function VideoGenerateForm() {
 
       {/* Duration + Aspect Ratio + Resolution */}
       <div className="grid gap-4 sm:grid-cols-3">
-        <div className="rounded-3xl border border-border/75 bg-card/82 p-5">
+        <div className="min-w-0 rounded-3xl border border-border/75 bg-card/82 p-5">
           <label
             className={cn(
               'mb-3 block text-xs font-semibold text-muted-foreground',
@@ -286,7 +286,7 @@ export default function VideoGenerateForm() {
           </div>
         </div>
 
-        <div className="rounded-3xl border border-border/75 bg-card/82 p-5">
+        <div className="min-w-0 rounded-3xl border border-border/75 bg-card/82 p-5">
           <label
             className={cn(
               'mb-3 block text-xs font-semibold text-muted-foreground',
@@ -314,7 +314,7 @@ export default function VideoGenerateForm() {
           </div>
         </div>
 
-        <div className="rounded-3xl border border-border/75 bg-card/82 p-5">
+        <div className="min-w-0 rounded-3xl border border-border/75 bg-card/82 p-5">
           <label
             className={cn(
               'mb-3 block text-xs font-semibold text-muted-foreground',


### PR DESCRIPTION
## Summary
- Add `min-w-0` and `overflow-hidden` to grid/flex children in GenerateForm, ModelSelector, VideoGenerateForm, and `.editorial-panel` CSS
- Hide SelectTrigger badges on mobile (`hidden sm:flex`) to prevent trigger overflow
- Fixes horizontal scrollbar on ~375px viewport for `/studio` page

## Test plan
- [ ] Open `/zh/studio` at 375px width — no horizontal scrollbar
- [ ] SelectTrigger shows model name truncated, badges visible at sm+
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)