### PR TITLE
feat: add aspect ratio selector to image generation form

### DIFF
--- a/src/components/business/GenerateForm.tsx
+++ b/src/components/business/GenerateForm.tsx
@@ -18,6 +18,8 @@ import {
   API_USAGE,
   DEFAULT_ASPECT_RATIO,
   GENERATION_LIMITS,
+  IMAGE_SIZES,
+  type AspectRatio,
 } from '@/constants/config'
 import {
   AI_MODELS,
@@ -81,6 +83,8 @@ export function GenerateForm() {
   const [selectedOptionId, setSelectedOptionId] = useState<string>(
     `workspace:${AI_MODELS.SDXL}`,
   )
+  const [aspectRatio, setAspectRatio] =
+    useState<AspectRatio>(DEFAULT_ASPECT_RATIO)
   const [referenceImage, setReferenceImage] = useState<string | undefined>()
   const [showReferencePanel, setShowReferencePanel] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
@@ -169,7 +173,7 @@ export function GenerateForm() {
     await generate({
       prompt: prompt.trim(),
       modelId: selectedModel.modelId,
-      aspectRatio: DEFAULT_ASPECT_RATIO,
+      aspectRatio,
       referenceImage,
       apiKeyId: selectedModel.keyId,
     })
@@ -521,6 +525,37 @@ export function GenerateForm() {
                 />
               </div>
             ) : null}
+          </div>
+
+          {/* Aspect Ratio Selector */}
+          <div className="mt-5 rounded-3xl border border-border/70 bg-background/46 p-4">
+            <p
+              className={cn(
+                'mb-3 text-xs font-semibold text-muted-foreground',
+                isDenseLocale
+                  ? 'tracking-normal normal-case'
+                  : 'uppercase tracking-[0.18em]',
+              )}
+            >
+              {t('aspectRatioLabel')}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {(Object.keys(IMAGE_SIZES) as AspectRatio[]).map((ar) => (
+                <button
+                  key={ar}
+                  type="button"
+                  onClick={() => setAspectRatio(ar)}
+                  className={cn(
+                    'rounded-full px-4 py-2 text-sm font-medium transition-colors',
+                    aspectRatio === ar
+                      ? 'bg-foreground text-background'
+                      : 'border border-border/75 bg-background/50 text-foreground hover:bg-muted/30',
+                  )}
+                >
+                  {ar}
+                </button>
+              ))}
+            </div>
           </div>
 
           {/* Reverse Engineer Panel */}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -326,6 +326,7 @@
     "promptHint": "Describe the subject, setting, light, composition, or style as clearly as you can.",
     "promptPlaceholder": "Describe the image you want to generate...",
     "promptCounter": "{current} / {max} characters",
+    "aspectRatioLabel": "Aspect Ratio",
     "referenceTitle": "Reference image",
     "referenceSelectedDescription": "Image selected. The next run will use it as reference guidance.",
     "referenceIdleDescription": "Optional. Upload a reference image when you want the generation to follow an existing composition or mood.",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -326,6 +326,7 @@
     "promptHint": "被写体、場面、ライティング、構図、スタイルなどをできるだけ明確に書いてください。",
     "promptPlaceholder": "生成したい画像を説明してください...",
     "promptCounter": "{current} / {max} 文字",
+    "aspectRatioLabel": "アスペクト比",
     "referenceTitle": "参照画像",
     "referenceSelectedDescription": "画像を選択済みです。次回の生成では参照画像として使われます。",
     "referenceIdleDescription": "任意です。既存の構図や雰囲気をなぞりたいときに参照画像をアップロードしてください。",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -326,6 +326,7 @@
     "promptHint": "描述主体、场景、光线、风格。",
     "promptPlaceholder": "描述你想生成的图像...",
     "promptCounter": "{current} / {max} 字符",
+    "aspectRatioLabel": "宽高比",
     "referenceTitle": "参考图像",
     "referenceSelectedDescription": "已选择图像。下一次生成会把它作为参考。",
     "referenceIdleDescription": "可选。上传参考图引导构图。",


### PR DESCRIPTION
## Summary
- Added aspect ratio selector (1:1, 16:9, 9:16, 4:3, 3:4) to `GenerateForm`, replacing the hardcoded 1:1 default
- Added `aspectRatioLabel` i18n key to en/zh/ja locale files
- Reuses existing `IMAGE_SIZES` config and `AspectRatio` type from constants

## Test plan
- [ ] Open Studio, verify aspect ratio buttons render below the reference image panel
- [ ] Select each ratio and generate an image — confirm the output dimensions match
- [ ] Switch locale to zh/ja and verify the label displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)