### PR TITLE
feat: persist and display reference images, aspect ratio selector & arena improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,9 @@ model Generation {
   // 視頻專用（圖片留 null）
   duration Float? // 秒數，例如 5.0
 
+  // ── 參考圖片 ────────────────────────────────────────────────────
+  referenceImageUrl String? // R2 永久 URL（用戶上傳的參考圖）
+
   // ── Prompt ────────────────────────────────────────────────────
   prompt         String  @db.Text
   negativePrompt String? @db.Text
@@ -92,7 +95,8 @@ model Generation {
   requestCount Int @default(1)
 
   // ── 可見性 ────────────────────────────────────────────────────
-  isPublic Boolean @default(true)
+  isPublic       Boolean @default(false)
+  isPromptPublic Boolean @default(false)
 
   // ── 關聯 ──────────────────────────────────────────────────────
   userId         String?

--- a/src/components/business/ImageCard.tsx
+++ b/src/components/business/ImageCard.tsx
@@ -3,7 +3,14 @@
 
 import { useState } from 'react'
 
-import { ArrowUpRight, Coins, Globe2, LockKeyhole, Play } from 'lucide-react'
+import {
+  ArrowUpRight,
+  Coins,
+  Globe2,
+  ImageIcon,
+  LockKeyhole,
+  Play,
+} from 'lucide-react'
 import { useFormatter, useLocale, useTranslations } from 'next-intl'
 
 import { getModelMessageKey, isBuiltInModel } from '@/constants/models'
@@ -114,6 +121,12 @@ export function ImageCard({
               style={{ aspectRatio }}
             />
           </button>
+          {generation.referenceImageUrl && (
+            <span className="absolute left-3 top-3 flex items-center gap-1.5 rounded-full bg-foreground/60 px-2 py-1 text-xs text-background backdrop-blur-sm">
+              <ImageIcon className="size-3" />
+              {t('referenceImageLabel')}
+            </span>
+          )}
           {generation.outputType === 'VIDEO' && (
             <>
               <span className="absolute bottom-3 left-3 flex size-8 items-center justify-center rounded-full bg-foreground/60 text-background backdrop-blur-sm">

--- a/src/components/business/ImageDetailModal.tsx
+++ b/src/components/business/ImageDetailModal.tsx
@@ -8,6 +8,7 @@ import {
   Coins,
   Download,
   Globe2,
+  ImageIcon,
   LockKeyhole,
   Trash2,
 } from 'lucide-react'
@@ -193,6 +194,27 @@ export function ImageDetailModal({
               <p className="font-serif text-sm leading-6 text-muted-foreground">
                 {generation.negativePrompt}
               </p>
+            </div>
+          ) : null}
+
+          {generation.referenceImageUrl ? (
+            <div className="space-y-2">
+              <p className={cn(labelClass, 'flex items-center gap-1.5')}>
+                <ImageIcon className="size-3" />
+                {t('referenceImageLabel')}
+              </p>
+              <a
+                href={generation.referenceImageUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="block w-fit"
+              >
+                <img
+                  src={generation.referenceImageUrl}
+                  alt={t('referenceImageLabel')}
+                  className="h-auto max-h-40 rounded-xl border border-border/70 object-contain"
+                />
+              </a>
             </div>
           ) : null}
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -491,12 +491,14 @@
     "deleteConfirmTitle": "Delete this generation?",
     "deleteConfirmDescription": "This will permanently delete this generation and its stored file. This action cannot be undone.",
     "deleteCancel": "Cancel",
-    "deleteConfirm": "Delete permanently"
+    "deleteConfirm": "Delete permanently",
+    "referenceImageLabel": "Reference Image"
   },
   "GalleryCard": {
     "openImage": "Open image in a new tab",
     "openLabel": "Open",
     "modelLabel": "Model",
+    "referenceImageLabel": "Ref",
     "providerLabel": "Provider",
     "requestsLabel": "Requests",
     "visibilityLabel": "Visibility",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -491,12 +491,14 @@
     "deleteConfirmTitle": "この作品を削除しますか？",
     "deleteConfirmDescription": "この作品とストレージファイルが完全に削除されます。この操作は元に戻せません。",
     "deleteCancel": "キャンセル",
-    "deleteConfirm": "完全に削除"
+    "deleteConfirm": "完全に削除",
+    "referenceImageLabel": "参照画像"
   },
   "GalleryCard": {
     "openImage": "画像を新しいタブで開く",
     "openLabel": "開く",
     "modelLabel": "モデル",
+    "referenceImageLabel": "参照",
     "providerLabel": "プロバイダー",
     "requestsLabel": "リクエスト",
     "visibilityLabel": "公開設定",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -491,12 +491,14 @@
     "deleteConfirmTitle": "确定删除此作品？",
     "deleteConfirmDescription": "此作品及其存储文件将被永久删除，此操作不可恢复。",
     "deleteCancel": "取消",
-    "deleteConfirm": "永久删除"
+    "deleteConfirm": "永久删除",
+    "referenceImageLabel": "参考图"
   },
   "GalleryCard": {
     "openImage": "在新标签页中打开图像",
     "openLabel": "查看",
     "modelLabel": "模型",
+    "referenceImageLabel": "参考",
     "providerLabel": "提供商",
     "requestsLabel": "请求数",
     "visibilityLabel": "可见性",

--- a/src/services/generate-image.service.ts
+++ b/src/services/generate-image.service.ts
@@ -234,6 +234,20 @@ export async function generateImageForUser(
   const storageKey = generateStorageKey('IMAGE', dbUser.id)
 
   try {
+    // Upload reference image to R2 if provided
+    let referenceImageUrl: string | undefined
+    if (input.referenceImage) {
+      const refKey = generateStorageKey('IMAGE', dbUser.id)
+      const { buffer: refBuffer, mimeType: refMimeType } = await fetchAsBuffer(
+        input.referenceImage,
+      )
+      referenceImageUrl = await uploadToR2({
+        data: refBuffer,
+        key: refKey,
+        mimeType: refMimeType,
+      })
+    }
+
     const { buffer, mimeType } = await fetchAsBuffer(generatedAsset.imageUrl)
     const permanentUrl = await uploadToR2({
       data: buffer,
@@ -247,6 +261,7 @@ export async function generateImageForUser(
       mimeType,
       width: generatedAsset.width,
       height: generatedAsset.height,
+      referenceImageUrl,
       prompt: input.prompt,
       model: executionRoute.modelId,
       provider,

--- a/src/services/generate-video.service.ts
+++ b/src/services/generate-video.service.ts
@@ -12,7 +12,12 @@ import type {
 } from '@/types'
 import { createGeneration } from '@/services/generation.service'
 import { getProviderAdapter } from '@/services/providers/registry'
-import { generateStorageKey, streamUploadToR2 } from '@/services/storage/r2'
+import {
+  fetchAsBuffer,
+  generateStorageKey,
+  streamUploadToR2,
+  uploadToR2,
+} from '@/services/storage/r2'
 import {
   attachUsageEntryToGeneration,
   completeGenerationJob,
@@ -64,6 +69,20 @@ export async function submitVideoGeneration(
     videoDefaults: modelConfig?.videoDefaults as Record<string, unknown>,
   })
 
+  // Upload reference image to R2 if provided
+  let referenceImageUrl: string | undefined
+  if (input.referenceImage) {
+    const refKey = generateStorageKey('IMAGE', dbUser.id)
+    const { buffer: refBuffer, mimeType: refMimeType } = await fetchAsBuffer(
+      input.referenceImage,
+    )
+    referenceImageUrl = await uploadToR2({
+      data: refBuffer,
+      key: refKey,
+      mimeType: refMimeType,
+    })
+  }
+
   const generationJob = await createGenerationJob({
     userId: dbUser.id,
     adapterType: executionRoute.adapterType,
@@ -76,6 +95,7 @@ export async function submitVideoGeneration(
     requestId: queueResult.requestId,
     statusUrl: queueResult.statusUrl,
     responseUrl: queueResult.responseUrl,
+    referenceImageUrl,
   })
 
   await db.generationJob.update({
@@ -133,7 +153,12 @@ export async function checkVideoGenerationStatus(
   }
 
   // Parse stored queue metadata
-  let queueMeta: { requestId: string; statusUrl: string; responseUrl: string }
+  let queueMeta: {
+    requestId: string
+    statusUrl: string
+    responseUrl: string
+    referenceImageUrl?: string
+  }
   try {
     queueMeta = JSON.parse(job.externalRequestId)
   } catch {
@@ -234,6 +259,7 @@ export async function checkVideoGenerationStatus(
       width: videoResult.width,
       height: videoResult.height,
       duration: videoResult.duration,
+      referenceImageUrl: queueMeta.referenceImageUrl,
       prompt: job.prompt ?? '',
       model: job.modelId,
       provider,

--- a/src/services/generation.service.ts
+++ b/src/services/generation.service.ts
@@ -18,6 +18,7 @@ export interface CreateGenerationInput {
   width: number
   height: number
   duration?: number
+  referenceImageUrl?: string
   prompt: string
   negativePrompt?: string
   model: string
@@ -96,13 +97,14 @@ export async function createGeneration(
       width: input.width,
       height: input.height,
       duration: input.duration,
+      referenceImageUrl: input.referenceImageUrl,
       prompt: input.prompt,
       negativePrompt: input.negativePrompt,
       model: input.model,
       provider: input.provider,
       requestCount: input.requestCount,
       outputType: input.outputType ?? 'IMAGE',
-      isPublic: input.isPublic ?? true,
+      isPublic: input.isPublic ?? false,
       userId: input.userId,
     },
   })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -137,6 +137,7 @@ export interface GenerationRecord {
   width: number
   height: number
   duration?: number | null
+  referenceImageUrl?: string | null
   prompt: string
   negativePrompt?: string | null
   model: string


### PR DESCRIPTION
## Summary
- **Reference image persistence**: Upload reference images to R2 and save URLs in Generation records, displayed as badges on ImageCard and full thumbnails in ImageDetailModal
- **Aspect ratio selector**: Add aspect ratio picker to the image generation form
- **Arena fan-out**: Refactor arena to parallel entry generation pattern
- **Studio mobile fix**: Prevent horizontal overflow on studio page at mobile viewport
- **API key routing**: Pass user-selected apiKeyId to image analysis and prompt enhance
- **Timeout improvements**: Increase video/generation timeouts and improve LLM key error messages

## Test plan
- [ ] Generate an image with a reference image and verify the reference appears in the card badge and detail modal
- [ ] Generate an image without a reference image and verify no badge appears
- [ ] Test aspect ratio selector in generation form
- [ ] Verify arena match creation with parallel entries
- [ ] Check studio page on mobile for no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)