### PR TITLE
refactor: extract shared hooks, UI components, and decompose large mo…

### DIFF
--- a/src/components/business/ApiKeyForm.tsx
+++ b/src/components/business/ApiKeyForm.tsx
@@ -1,0 +1,376 @@
+'use client'
+
+import { useState } from 'react'
+import { ExternalLink, Eye, EyeOff, Loader2, Plus } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+import { API_KEY_ADAPTER_OPTIONS } from '@/constants/api-keys'
+import {
+  AI_MODELS,
+  getAvailableModels,
+  getModelMessageKey,
+} from '@/constants/models'
+import {
+  AI_ADAPTER_TYPES,
+  getAdapterApiGuide,
+  getAdapterCustomModelExample,
+  getAdapterKeyHint,
+  getDefaultProviderConfig,
+} from '@/constants/providers'
+import type { CreateApiKeyRequest } from '@/types'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+
+type EntryMode = 'preset' | 'custom'
+
+interface ApiKeyFormProps {
+  onAdd: (data: CreateApiKeyRequest) => Promise<void>
+  onCancel: () => void
+  isSubmitting: boolean
+}
+
+export function ApiKeyForm({ onAdd, onCancel, isSubmitting }: ApiKeyFormProps) {
+  const t = useTranslations('StudioApiKeys')
+  const tModels = useTranslations('Models')
+  const availableModels = getAvailableModels()
+  const [adapterType, setAdapterType] = useState<AI_ADAPTER_TYPES>(
+    AI_ADAPTER_TYPES.HUGGINGFACE,
+  )
+  const [entryMode, setEntryMode] = useState<EntryMode>('preset')
+  const modelsForAdapter = availableModels.filter(
+    (model) => model.adapterType === adapterType,
+  )
+  const firstAdapterModelId = modelsForAdapter[0]?.id ?? AI_MODELS.SDXL
+  const defaultProviderConfig = getDefaultProviderConfig(adapterType)
+  const [presetModelId, setPresetModelId] =
+    useState<AI_MODELS>(firstAdapterModelId)
+  const [customModelId, setCustomModelId] = useState('')
+  const [providerLabel, setProviderLabel] = useState(
+    defaultProviderConfig.label,
+  )
+  const [providerBaseUrl, setProviderBaseUrl] = useState(
+    defaultProviderConfig.baseUrl,
+  )
+  const [label, setLabel] = useState('')
+  const [keyValue, setKeyValue] = useState('')
+  const [showKey, setShowKey] = useState(false)
+
+  const resolvedPresetModelId = modelsForAdapter.some(
+    (model) => model.id === presetModelId,
+  )
+    ? presetModelId
+    : firstAdapterModelId
+
+  const resolvedModelId =
+    entryMode === 'preset' ? resolvedPresetModelId : customModelId.trim()
+  const resolvedProviderLabel =
+    providerLabel.trim() || defaultProviderConfig.label
+  const resolvedProviderBaseUrl =
+    providerBaseUrl.trim() || defaultProviderConfig.baseUrl
+  const isSubmitDisabled =
+    isSubmitting ||
+    !resolvedModelId ||
+    !resolvedProviderLabel ||
+    !resolvedProviderBaseUrl ||
+    !label.trim() ||
+    !keyValue.trim()
+
+  const handleAdapterChange = (nextAdapterType: AI_ADAPTER_TYPES) => {
+    setAdapterType(nextAdapterType)
+    const nextProviderConfig = getDefaultProviderConfig(nextAdapterType)
+    const nextModels = availableModels.filter(
+      (model) => model.adapterType === nextAdapterType,
+    )
+
+    setProviderLabel(nextProviderConfig.label)
+    setProviderBaseUrl(nextProviderConfig.baseUrl)
+    setPresetModelId(nextModels[0]?.id ?? AI_MODELS.SDXL)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (isSubmitDisabled) return
+
+    await onAdd({
+      adapterType,
+      providerConfig: {
+        label: resolvedProviderLabel,
+        baseUrl: resolvedProviderBaseUrl,
+      },
+      modelId: resolvedModelId,
+      label: label.trim(),
+      keyValue: keyValue.trim(),
+    })
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-5 rounded-3xl border border-border/70 bg-card/84 p-5"
+    >
+      <div className="space-y-1">
+        <h3 className="font-display text-base font-medium text-foreground">
+          {t('addForm.title')}
+        </h3>
+        <p className="font-serif text-sm leading-6 text-muted-foreground">
+          {t('addForm.description')}
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">
+          {t('addForm.adapterLabel')}
+        </p>
+        <div className="grid gap-2 sm:grid-cols-3">
+          {API_KEY_ADAPTER_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => handleAdapterChange(option)}
+              className={cn(
+                'rounded-2xl border px-4 py-3 text-left transition-colors',
+                adapterType === option
+                  ? 'border-primary/25 bg-primary/6'
+                  : 'border-border/70 bg-background/72 hover:bg-secondary/24',
+              )}
+            >
+              <p className="font-medium text-foreground">
+                {t(`providers.${option}.label`)}
+              </p>
+              <p className="mt-1 font-serif text-xs leading-5 text-muted-foreground">
+                {t(`providers.${option}.description`)}
+              </p>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
+        <div className="space-y-2">
+          <label
+            htmlFor="provider-label"
+            className="text-sm font-medium text-foreground"
+          >
+            {t('addForm.providerNameLabel')}
+          </label>
+          <Input
+            id="provider-label"
+            value={providerLabel}
+            onChange={(e) => setProviderLabel(e.target.value)}
+            placeholder={defaultProviderConfig.label}
+            maxLength={60}
+            className="h-11 rounded-2xl border-border/70 bg-background/80"
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label
+            htmlFor="provider-base-url"
+            className="text-sm font-medium text-foreground"
+          >
+            {t('addForm.providerBaseUrlLabel')}
+          </label>
+          <Input
+            id="provider-base-url"
+            type="url"
+            value={providerBaseUrl}
+            onChange={(e) => setProviderBaseUrl(e.target.value)}
+            placeholder={defaultProviderConfig.baseUrl}
+            className="h-11 rounded-2xl border-border/70 bg-background/80 font-mono"
+            required
+          />
+          <p className="text-xs leading-5 text-muted-foreground">
+            {t('addForm.providerBaseUrlHint')}
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">
+          {t('addForm.modelModeLabel')}
+        </p>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {(['preset', 'custom'] as EntryMode[]).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => setEntryMode(mode)}
+              className={cn(
+                'rounded-2xl border px-4 py-3 text-left transition-colors',
+                entryMode === mode
+                  ? 'border-primary/25 bg-primary/6'
+                  : 'border-border/70 bg-background/72 hover:bg-secondary/24',
+              )}
+            >
+              <p className="font-medium text-foreground">
+                {t(`addForm.modelModes.${mode}.label`)}
+              </p>
+              <p className="mt-1 font-serif text-xs leading-5 text-muted-foreground">
+                {t(`addForm.modelModes.${mode}.description`)}
+              </p>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {entryMode === 'preset' ? (
+        <div className="space-y-2">
+          <label
+            htmlFor="preset-model-select"
+            className="text-sm font-medium text-foreground"
+          >
+            {t('addForm.presetModelLabel')}
+          </label>
+          <Select
+            name="presetModelId"
+            value={resolvedPresetModelId}
+            onValueChange={(value) => setPresetModelId(value as AI_MODELS)}
+          >
+            <SelectTrigger
+              id="preset-model-select"
+              className="h-11 rounded-2xl border-border/70 bg-background/80"
+            >
+              <SelectValue placeholder={t('addForm.presetModelPlaceholder')} />
+            </SelectTrigger>
+            <SelectContent>
+              {modelsForAdapter.map((model) => (
+                <SelectItem key={model.id} value={model.id}>
+                  {tModels(`${getModelMessageKey(model.id)}.label`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <label
+            htmlFor="custom-model-id"
+            className="text-sm font-medium text-foreground"
+          >
+            {t('addForm.customModelLabel')}
+          </label>
+          <Input
+            id="custom-model-id"
+            value={customModelId}
+            onChange={(e) => setCustomModelId(e.target.value)}
+            placeholder={getAdapterCustomModelExample(adapterType)}
+            className="h-11 rounded-2xl border-border/70 bg-background/80 font-mono"
+            required
+          />
+          <p className="text-xs text-muted-foreground">
+            {t('addForm.customModelHint', {
+              provider: resolvedProviderLabel,
+            })}
+          </p>
+        </div>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label
+            htmlFor="api-key-label"
+            className="text-sm font-medium text-foreground"
+          >
+            {t('addForm.labelLabel')}
+          </label>
+          <Input
+            id="api-key-label"
+            placeholder={t('addForm.labelPlaceholder')}
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            maxLength={50}
+            className="h-11 rounded-2xl border-border/70 bg-background/80"
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label
+            htmlFor="api-key-value"
+            className="text-sm font-medium text-foreground"
+          >
+            {t('addForm.keyLabel')}
+          </label>
+          <div className="relative">
+            <Input
+              id="api-key-value"
+              type={showKey ? 'text' : 'password'}
+              placeholder={getAdapterKeyHint(adapterType)}
+              value={keyValue}
+              onChange={(e) => setKeyValue(e.target.value)}
+              className="h-11 rounded-2xl border-border/70 bg-background/80 pr-11 font-mono"
+              required
+            />
+            <button
+              type="button"
+              onClick={() => setShowKey((value) => !value)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+              aria-label={showKey ? t('addForm.hideKey') : t('addForm.showKey')}
+            >
+              {showKey ? (
+                <EyeOff className="size-4" />
+              ) : (
+                <Eye className="size-4" />
+              )}
+            </button>
+          </div>
+          {(() => {
+            const guide = getAdapterApiGuide(adapterType)
+            return (
+              <div className="mt-1.5 space-y-0.5">
+                <p className="text-xs text-muted-foreground">{guide.steps}</p>
+                <a
+                  href={guide.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                >
+                  {t('addForm.getKeyLink')}
+                  <ExternalLink className="size-3" />
+                </a>
+              </div>
+            )
+          })()}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="submit"
+          disabled={isSubmitDisabled}
+          className="rounded-full px-5"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              {t('addForm.savingAction')}
+            </>
+          ) : (
+            <>
+              <Plus className="size-4" />
+              {t('addForm.saveAction')}
+            </>
+          )}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onCancel}
+          className="rounded-full px-5"
+        >
+          {t('addForm.cancelAction')}
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/business/ApiKeyHealthDot.tsx
+++ b/src/components/business/ApiKeyHealthDot.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+
+import type { ApiKeyHealthStatus } from '@/types'
+import { cn } from '@/lib/utils'
+
+const HEALTH_COLORS: Record<ApiKeyHealthStatus, string> = {
+  available: 'bg-emerald-500',
+  no_key: 'bg-amber-500',
+  failed: 'bg-red-500',
+}
+
+export function ApiKeyHealthDot({
+  status,
+}: {
+  status: ApiKeyHealthStatus | undefined
+}) {
+  const t = useTranslations('StudioApiKeys')
+
+  if (!status) return null
+
+  const label = t(`health.${status === 'no_key' ? 'noKey' : status}`)
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
+      title={label}
+    >
+      <span
+        className={cn('size-2 shrink-0 rounded-full', HEALTH_COLORS[status])}
+      />
+      {label}
+    </span>
+  )
+}

--- a/src/components/business/ApiKeyManager.tsx
+++ b/src/components/business/ApiKeyManager.tsx
@@ -2,73 +2,37 @@
 
 import { useState } from 'react'
 import {
-  CheckCircle2,
   ChevronDown,
   ChevronRight,
-  Circle,
-  ExternalLink,
-  Eye,
-  EyeOff,
   KeyRound,
   Loader2,
   Plus,
-  ShieldCheck,
   Sparkles,
-  Trash2,
 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
-import { API_KEY_ADAPTER_OPTIONS } from '@/constants/api-keys'
 import {
-  AI_MODELS,
   getAvailableModels,
   getModelMessageKey,
   isBuiltInModel,
 } from '@/constants/models'
 import {
   AI_ADAPTER_TYPES,
-  getAdapterApiGuide,
-  getAdapterCustomModelExample,
-  getAdapterKeyHint,
   getDefaultProviderConfig,
   getProviderLabel,
 } from '@/constants/providers'
 import type {
-  ApiKeyHealthStatus,
   CreateApiKeyRequest,
   UpdateApiKeyRequest,
   UserApiKeyRecord,
 } from '@/types'
-import { useApiKeysContext } from '@/contexts/api-keys-context'
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog'
+import { ApiKeyForm } from '@/components/business/ApiKeyForm'
+import { ApiKeyRow } from '@/components/business/ApiKeyRow'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
-import { cn } from '@/lib/utils'
-
-type EntryMode = 'preset' | 'custom'
-type MessageGetter = (
-  key: string,
-  values?: Record<string, string | number>,
-) => string
+import { useApiKeysContext } from '@/contexts/api-keys-context'
+import { getTranslatedModelLabel } from '@/lib/model-options'
 
 interface ProviderRouteGroup {
   groupId: string
@@ -76,542 +40,6 @@ interface ProviderRouteGroup {
   adapterType: AI_ADAPTER_TYPES
   keys: UserApiKeyRecord[]
 }
-
-function getModelDisplayLabel(tModels: MessageGetter, modelId: string): string {
-  if (isBuiltInModel(modelId)) {
-    return tModels(`${getModelMessageKey(modelId)}.label`)
-  }
-
-  return modelId
-}
-
-// ─── Health Status Dot ──────────────────────────────────────────────
-
-function HealthDot({ status }: { status: ApiKeyHealthStatus | undefined }) {
-  const t = useTranslations('StudioApiKeys')
-
-  if (!status) return null
-
-  const config: Record<ApiKeyHealthStatus, { color: string; label: string }> = {
-    available: {
-      color: 'bg-emerald-500',
-      label: t('health.available'),
-    },
-    no_key: {
-      color: 'bg-amber-500',
-      label: t('health.noKey'),
-    },
-    failed: {
-      color: 'bg-red-500',
-      label: t('health.failed'),
-    },
-  }
-
-  const { color, label } = config[status]
-
-  return (
-    <span
-      className="inline-flex items-center gap-1.5 text-xs text-muted-foreground"
-      title={label}
-    >
-      <span className={cn('size-2 shrink-0 rounded-full', color)} />
-      {label}
-    </span>
-  )
-}
-
-// ─── Add Key Form ──────────────────────────────────────────────────
-
-interface AddKeyFormProps {
-  onAdd: (data: CreateApiKeyRequest) => Promise<void>
-  onCancel: () => void
-  isSubmitting: boolean
-}
-
-function AddKeyForm({ onAdd, onCancel, isSubmitting }: AddKeyFormProps) {
-  const t = useTranslations('StudioApiKeys')
-  const tModels = useTranslations('Models')
-  const availableModels = getAvailableModels()
-  const [adapterType, setAdapterType] = useState<AI_ADAPTER_TYPES>(
-    AI_ADAPTER_TYPES.HUGGINGFACE,
-  )
-  const [entryMode, setEntryMode] = useState<EntryMode>('preset')
-  const modelsForAdapter = availableModels.filter(
-    (model) => model.adapterType === adapterType,
-  )
-  const firstAdapterModelId = modelsForAdapter[0]?.id ?? AI_MODELS.SDXL
-  const defaultProviderConfig = getDefaultProviderConfig(adapterType)
-  const [presetModelId, setPresetModelId] =
-    useState<AI_MODELS>(firstAdapterModelId)
-  const [customModelId, setCustomModelId] = useState('')
-  const [providerLabel, setProviderLabel] = useState(
-    defaultProviderConfig.label,
-  )
-  const [providerBaseUrl, setProviderBaseUrl] = useState(
-    defaultProviderConfig.baseUrl,
-  )
-  const [label, setLabel] = useState('')
-  const [keyValue, setKeyValue] = useState('')
-  const [showKey, setShowKey] = useState(false)
-
-  const resolvedPresetModelId = modelsForAdapter.some(
-    (model) => model.id === presetModelId,
-  )
-    ? presetModelId
-    : firstAdapterModelId
-
-  const resolvedModelId =
-    entryMode === 'preset' ? resolvedPresetModelId : customModelId.trim()
-  const resolvedProviderLabel =
-    providerLabel.trim() || defaultProviderConfig.label
-  const resolvedProviderBaseUrl =
-    providerBaseUrl.trim() || defaultProviderConfig.baseUrl
-  const isSubmitDisabled =
-    isSubmitting ||
-    !resolvedModelId ||
-    !resolvedProviderLabel ||
-    !resolvedProviderBaseUrl ||
-    !label.trim() ||
-    !keyValue.trim()
-
-  const handleAdapterChange = (nextAdapterType: AI_ADAPTER_TYPES) => {
-    setAdapterType(nextAdapterType)
-    const nextProviderConfig = getDefaultProviderConfig(nextAdapterType)
-    const nextModels = availableModels.filter(
-      (model) => model.adapterType === nextAdapterType,
-    )
-
-    setProviderLabel(nextProviderConfig.label)
-    setProviderBaseUrl(nextProviderConfig.baseUrl)
-    setPresetModelId(nextModels[0]?.id ?? AI_MODELS.SDXL)
-  }
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (isSubmitDisabled) return
-
-    await onAdd({
-      adapterType,
-      providerConfig: {
-        label: resolvedProviderLabel,
-        baseUrl: resolvedProviderBaseUrl,
-      },
-      modelId: resolvedModelId,
-      label: label.trim(),
-      keyValue: keyValue.trim(),
-    })
-  }
-
-  return (
-    <form
-      onSubmit={handleSubmit}
-      className="space-y-5 rounded-3xl border border-border/70 bg-card/84 p-5"
-    >
-      <div className="space-y-1">
-        <h3 className="font-display text-base font-medium text-foreground">
-          {t('addForm.title')}
-        </h3>
-        <p className="font-serif text-sm leading-6 text-muted-foreground">
-          {t('addForm.description')}
-        </p>
-      </div>
-
-      <div className="space-y-2">
-        <p className="text-sm font-medium text-foreground">
-          {t('addForm.adapterLabel')}
-        </p>
-        <div className="grid gap-2 sm:grid-cols-3">
-          {API_KEY_ADAPTER_OPTIONS.map((option) => (
-            <button
-              key={option}
-              type="button"
-              onClick={() => handleAdapterChange(option)}
-              className={cn(
-                'rounded-2xl border px-4 py-3 text-left transition-colors',
-                adapterType === option
-                  ? 'border-primary/25 bg-primary/6'
-                  : 'border-border/70 bg-background/72 hover:bg-secondary/24',
-              )}
-            >
-              <p className="font-medium text-foreground">
-                {t(`providers.${option}.label`)}
-              </p>
-              <p className="mt-1 font-serif text-xs leading-5 text-muted-foreground">
-                {t(`providers.${option}.description`)}
-              </p>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
-        <div className="space-y-2">
-          <label
-            htmlFor="provider-label"
-            className="text-sm font-medium text-foreground"
-          >
-            {t('addForm.providerNameLabel')}
-          </label>
-          <Input
-            id="provider-label"
-            value={providerLabel}
-            onChange={(e) => setProviderLabel(e.target.value)}
-            placeholder={defaultProviderConfig.label}
-            maxLength={60}
-            className="h-11 rounded-2xl border-border/70 bg-background/80"
-            required
-          />
-        </div>
-
-        <div className="space-y-2">
-          <label
-            htmlFor="provider-base-url"
-            className="text-sm font-medium text-foreground"
-          >
-            {t('addForm.providerBaseUrlLabel')}
-          </label>
-          <Input
-            id="provider-base-url"
-            type="url"
-            value={providerBaseUrl}
-            onChange={(e) => setProviderBaseUrl(e.target.value)}
-            placeholder={defaultProviderConfig.baseUrl}
-            className="h-11 rounded-2xl border-border/70 bg-background/80 font-mono"
-            required
-          />
-          <p className="text-xs leading-5 text-muted-foreground">
-            {t('addForm.providerBaseUrlHint')}
-          </p>
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <p className="text-sm font-medium text-foreground">
-          {t('addForm.modelModeLabel')}
-        </p>
-        <div className="grid gap-2 sm:grid-cols-2">
-          {(['preset', 'custom'] as EntryMode[]).map((mode) => (
-            <button
-              key={mode}
-              type="button"
-              onClick={() => setEntryMode(mode)}
-              className={cn(
-                'rounded-2xl border px-4 py-3 text-left transition-colors',
-                entryMode === mode
-                  ? 'border-primary/25 bg-primary/6'
-                  : 'border-border/70 bg-background/72 hover:bg-secondary/24',
-              )}
-            >
-              <p className="font-medium text-foreground">
-                {t(`addForm.modelModes.${mode}.label`)}
-              </p>
-              <p className="mt-1 font-serif text-xs leading-5 text-muted-foreground">
-                {t(`addForm.modelModes.${mode}.description`)}
-              </p>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {entryMode === 'preset' ? (
-        <div className="space-y-2">
-          <label
-            htmlFor="preset-model-select"
-            className="text-sm font-medium text-foreground"
-          >
-            {t('addForm.presetModelLabel')}
-          </label>
-          <Select
-            name="presetModelId"
-            value={resolvedPresetModelId}
-            onValueChange={(value) => setPresetModelId(value as AI_MODELS)}
-          >
-            <SelectTrigger
-              id="preset-model-select"
-              className="h-11 rounded-2xl border-border/70 bg-background/80"
-            >
-              <SelectValue placeholder={t('addForm.presetModelPlaceholder')} />
-            </SelectTrigger>
-            <SelectContent>
-              {modelsForAdapter.map((model) => (
-                <SelectItem key={model.id} value={model.id}>
-                  {tModels(`${getModelMessageKey(model.id)}.label`)}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          <label
-            htmlFor="custom-model-id"
-            className="text-sm font-medium text-foreground"
-          >
-            {t('addForm.customModelLabel')}
-          </label>
-          <Input
-            id="custom-model-id"
-            value={customModelId}
-            onChange={(e) => setCustomModelId(e.target.value)}
-            placeholder={getAdapterCustomModelExample(adapterType)}
-            className="h-11 rounded-2xl border-border/70 bg-background/80 font-mono"
-            required
-          />
-          <p className="text-xs text-muted-foreground">
-            {t('addForm.customModelHint', {
-              provider: resolvedProviderLabel,
-            })}
-          </p>
-        </div>
-      )}
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-2">
-          <label
-            htmlFor="api-key-label"
-            className="text-sm font-medium text-foreground"
-          >
-            {t('addForm.labelLabel')}
-          </label>
-          <Input
-            id="api-key-label"
-            placeholder={t('addForm.labelPlaceholder')}
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-            maxLength={50}
-            className="h-11 rounded-2xl border-border/70 bg-background/80"
-            required
-          />
-        </div>
-
-        <div className="space-y-2">
-          <label
-            htmlFor="api-key-value"
-            className="text-sm font-medium text-foreground"
-          >
-            {t('addForm.keyLabel')}
-          </label>
-          <div className="relative">
-            <Input
-              id="api-key-value"
-              type={showKey ? 'text' : 'password'}
-              placeholder={getAdapterKeyHint(adapterType)}
-              value={keyValue}
-              onChange={(e) => setKeyValue(e.target.value)}
-              className="h-11 rounded-2xl border-border/70 bg-background/80 pr-11 font-mono"
-              required
-            />
-            <button
-              type="button"
-              onClick={() => setShowKey((value) => !value)}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-              aria-label={showKey ? t('addForm.hideKey') : t('addForm.showKey')}
-            >
-              {showKey ? (
-                <EyeOff className="size-4" />
-              ) : (
-                <Eye className="size-4" />
-              )}
-            </button>
-          </div>
-          {(() => {
-            const guide = getAdapterApiGuide(adapterType)
-            return (
-              <div className="mt-1.5 space-y-0.5">
-                <p className="text-xs text-muted-foreground">{guide.steps}</p>
-                <a
-                  href={guide.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
-                >
-                  {t('addForm.getKeyLink')}
-                  <ExternalLink className="size-3" />
-                </a>
-              </div>
-            )
-          })()}
-        </div>
-      </div>
-
-      <div className="flex flex-wrap gap-2">
-        <Button
-          type="submit"
-          disabled={isSubmitDisabled}
-          className="rounded-full px-5"
-        >
-          {isSubmitting ? (
-            <>
-              <Loader2 className="size-4 animate-spin" />
-              {t('addForm.savingAction')}
-            </>
-          ) : (
-            <>
-              <Plus className="size-4" />
-              {t('addForm.saveAction')}
-            </>
-          )}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onCancel}
-          className="rounded-full px-5"
-        >
-          {t('addForm.cancelAction')}
-        </Button>
-      </div>
-    </form>
-  )
-}
-
-// ─── Key Row ───────────────────────────────────────────────────────
-
-interface KeyRowProps {
-  record: UserApiKeyRecord
-  healthStatus: ApiKeyHealthStatus | undefined
-  onToggle: (id: string, data: UpdateApiKeyRequest) => Promise<void>
-  onDelete: (id: string) => Promise<void>
-  onVerify: (id: string) => Promise<void>
-}
-
-function KeyRow({
-  record,
-  healthStatus,
-  onToggle,
-  onDelete,
-  onVerify,
-}: KeyRowProps) {
-  const t = useTranslations('StudioApiKeys')
-  const [isPending, setIsPending] = useState(false)
-  const [isDeleting, setIsDeleting] = useState(false)
-  const [isVerifying, setIsVerifying] = useState(false)
-
-  const handleToggle = async () => {
-    setIsPending(true)
-    await onToggle(record.id, { isActive: !record.isActive })
-    setIsPending(false)
-  }
-
-  const handleDelete = async () => {
-    setIsDeleting(true)
-    await onDelete(record.id)
-    setIsDeleting(false)
-  }
-
-  const handleVerify = async () => {
-    setIsVerifying(true)
-    await onVerify(record.id)
-    setIsVerifying(false)
-  }
-
-  return (
-    <div
-      className={cn(
-        'flex items-start gap-3 rounded-2xl border px-4 py-3 transition-colors',
-        record.isActive
-          ? 'border-primary/25 bg-primary/6'
-          : 'border-border/70 bg-background/76',
-      )}
-    >
-      <button
-        type="button"
-        onClick={handleToggle}
-        disabled={isPending}
-        className="mt-0.5 shrink-0 text-muted-foreground transition-colors hover:text-foreground disabled:cursor-default"
-        title={
-          record.isActive ? t('actions.disableRoute') : t('actions.enableRoute')
-        }
-      >
-        {isPending ? (
-          <Loader2 className="size-4 animate-spin" />
-        ) : record.isActive ? (
-          <CheckCircle2 className="size-4 text-primary" />
-        ) : (
-          <Circle className="size-4" />
-        )}
-      </button>
-
-      <div className="min-w-0 flex-1 space-y-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <p className="truncate text-sm font-medium text-foreground">
-            {record.label}
-          </p>
-          <Badge variant="outline" className="rounded-full px-3 py-1">
-            {getProviderLabel(record.providerConfig)}
-          </Badge>
-          <Badge
-            variant={record.isActive ? 'secondary' : 'outline'}
-            className="rounded-full px-3 py-1"
-          >
-            {record.isActive ? t('status.enabled') : t('status.disabled')}
-          </Badge>
-          <HealthDot status={healthStatus} />
-        </div>
-        <p className="font-mono text-xs text-muted-foreground">
-          {record.maskedKey}
-        </p>
-        <p className="truncate font-mono text-xs text-muted-foreground">
-          {record.providerConfig.baseUrl}
-        </p>
-      </div>
-
-      <div className="flex shrink-0 items-center gap-2">
-        <button
-          type="button"
-          onClick={handleVerify}
-          disabled={isVerifying}
-          className="text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
-          title={t('actions.verifyKey')}
-        >
-          {isVerifying ? (
-            <Loader2 className="size-4 animate-spin" />
-          ) : (
-            <ShieldCheck className="size-4" />
-          )}
-        </button>
-
-        <AlertDialog>
-          <AlertDialogTrigger asChild>
-            <button
-              type="button"
-              disabled={isDeleting}
-              className="text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
-              title={t('actions.deleteKey')}
-            >
-              {isDeleting ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <Trash2 className="size-4" />
-              )}
-            </button>
-          </AlertDialogTrigger>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>{t('deleteDialog.title')}</AlertDialogTitle>
-              <AlertDialogDescription>
-                {t('deleteDialog.description', { label: record.label })}
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>
-                {t('deleteDialog.cancelAction')}
-              </AlertDialogCancel>
-              <AlertDialogAction
-                onClick={handleDelete}
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-              >
-                {t('deleteDialog.confirmAction')}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
-      </div>
-    </div>
-  )
-}
-
-// ─── Helpers ───────────────────────────────────────────────────────
 
 function sortRouteRecords(records: UserApiKeyRecord[]): UserApiKeyRecord[] {
   return [...records].sort((left, right) => {
@@ -624,8 +52,6 @@ function sortRouteRecords(records: UserApiKeyRecord[]): UserApiKeyRecord[] {
     return left.isActive ? -1 : 1
   })
 }
-
-// ─── Main Component ────────────────────────────────────────────────
 
 export function ApiKeyManager() {
   const { keys, isLoading, error, healthMap, create, update, remove, verify } =
@@ -708,7 +134,7 @@ export function ApiKeyManager() {
 
   return (
     <div className="space-y-6">
-      {/* ── Header + Summary ─────────────────────────────────────── */}
+      {/* Header + Summary */}
       <div className="rounded-3xl border border-border/70 bg-secondary/18 p-5">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-1">
@@ -767,9 +193,9 @@ export function ApiKeyManager() {
         </div>
       </div>
 
-      {/* ── Add Form ─────────────────────────────────────────────── */}
+      {/* Add Form */}
       {showAddForm ? (
-        <AddKeyForm
+        <ApiKeyForm
           onAdd={handleAdd}
           onCancel={() => setShowAddForm(false)}
           isSubmitting={isSubmitting}
@@ -789,7 +215,7 @@ export function ApiKeyManager() {
         </div>
       ) : (
         <div className="space-y-6">
-          {/* ── Built-in Model Routes ──────────────────────────────── */}
+          {/* Built-in Model Routes */}
           <section className="space-y-4">
             <div className="flex items-center justify-between">
               <div className="space-y-1">
@@ -813,7 +239,7 @@ export function ApiKeyManager() {
                       <div className="space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
                           <h4 className="font-display text-sm font-medium text-foreground">
-                            {getModelDisplayLabel(tModels, group.modelId)}
+                            {getTranslatedModelLabel(tModels, group.modelId)}
                           </h4>
                           <Badge
                             variant="outline"
@@ -844,7 +270,7 @@ export function ApiKeyManager() {
                     <div className="mt-4 space-y-3">
                       {group.keys.length ? (
                         group.keys.map((record) => (
-                          <KeyRow
+                          <ApiKeyRow
                             key={record.id}
                             record={record}
                             healthStatus={healthMap[record.id]}
@@ -856,7 +282,10 @@ export function ApiKeyManager() {
                       ) : (
                         <div className="rounded-2xl border border-dashed border-border/70 bg-background/60 px-4 py-5 text-sm text-muted-foreground">
                           {t('emptyModel', {
-                            model: getModelDisplayLabel(tModels, group.modelId),
+                            model: getTranslatedModelLabel(
+                              tModels,
+                              group.modelId,
+                            ),
                           })}
                         </div>
                       )}
@@ -870,7 +299,6 @@ export function ApiKeyManager() {
               </div>
             ) : null}
 
-            {/* Toggle to show/hide all built-in models */}
             {allBuiltInGroups.length > activeBuiltInGroups.length ? (
               <button
                 type="button"
@@ -894,7 +322,7 @@ export function ApiKeyManager() {
             ) : null}
           </section>
 
-          {/* ── Custom Model Routes ────────────────────────────────── */}
+          {/* Custom Model Routes */}
           <section className="space-y-4">
             <div className="space-y-1">
               <h3 className="font-display text-sm font-medium text-foreground">
@@ -959,7 +387,7 @@ export function ApiKeyManager() {
 
                       <div className="mt-4 space-y-3">
                         {group.keys.map((record) => (
-                          <KeyRow
+                          <ApiKeyRow
                             key={record.id}
                             record={record}
                             healthStatus={healthMap[record.id]}
@@ -989,7 +417,6 @@ export function ApiKeyManager() {
               </div>
             ) : null}
 
-            {/* Toggle to show/hide all custom groups */}
             {allCustomGroups.length > activeCustomGroups.length ? (
               <button
                 type="button"

--- a/src/components/business/ApiKeyRow.tsx
+++ b/src/components/business/ApiKeyRow.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  CheckCircle2,
+  Circle,
+  Loader2,
+  ShieldCheck,
+  Trash2,
+} from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+import { getProviderLabel } from '@/constants/providers'
+import type {
+  ApiKeyHealthStatus,
+  UpdateApiKeyRequest,
+  UserApiKeyRecord,
+} from '@/types'
+
+import { ApiKeyHealthDot } from '@/components/business/ApiKeyHealthDot'
+import { Badge } from '@/components/ui/badge'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { cn } from '@/lib/utils'
+
+interface ApiKeyRowProps {
+  record: UserApiKeyRecord
+  healthStatus: ApiKeyHealthStatus | undefined
+  onToggle: (id: string, data: UpdateApiKeyRequest) => Promise<void>
+  onDelete: (id: string) => Promise<void>
+  onVerify: (id: string) => Promise<void>
+}
+
+export function ApiKeyRow({
+  record,
+  healthStatus,
+  onToggle,
+  onDelete,
+  onVerify,
+}: ApiKeyRowProps) {
+  const t = useTranslations('StudioApiKeys')
+  const [isPending, setIsPending] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [isVerifying, setIsVerifying] = useState(false)
+
+  const handleToggle = async () => {
+    setIsPending(true)
+    await onToggle(record.id, { isActive: !record.isActive })
+    setIsPending(false)
+  }
+
+  const handleDelete = async () => {
+    setIsDeleting(true)
+    await onDelete(record.id)
+    setIsDeleting(false)
+  }
+
+  const handleVerify = async () => {
+    setIsVerifying(true)
+    await onVerify(record.id)
+    setIsVerifying(false)
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-3 rounded-2xl border px-4 py-3 transition-colors',
+        record.isActive
+          ? 'border-primary/25 bg-primary/6'
+          : 'border-border/70 bg-background/76',
+      )}
+    >
+      <button
+        type="button"
+        onClick={handleToggle}
+        disabled={isPending}
+        className="mt-0.5 shrink-0 text-muted-foreground transition-colors hover:text-foreground disabled:cursor-default"
+        title={
+          record.isActive ? t('actions.disableRoute') : t('actions.enableRoute')
+        }
+      >
+        {isPending ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : record.isActive ? (
+          <CheckCircle2 className="size-4 text-primary" />
+        ) : (
+          <Circle className="size-4" />
+        )}
+      </button>
+
+      <div className="min-w-0 flex-1 space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="truncate text-sm font-medium text-foreground">
+            {record.label}
+          </p>
+          <Badge variant="outline" className="rounded-full px-3 py-1">
+            {getProviderLabel(record.providerConfig)}
+          </Badge>
+          <Badge
+            variant={record.isActive ? 'secondary' : 'outline'}
+            className="rounded-full px-3 py-1"
+          >
+            {record.isActive ? t('status.enabled') : t('status.disabled')}
+          </Badge>
+          <ApiKeyHealthDot status={healthStatus} />
+        </div>
+        <p className="font-mono text-xs text-muted-foreground">
+          {record.maskedKey}
+        </p>
+        <p className="truncate font-mono text-xs text-muted-foreground">
+          {record.providerConfig.baseUrl}
+        </p>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={handleVerify}
+          disabled={isVerifying}
+          className="text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+          title={t('actions.verifyKey')}
+        >
+          {isVerifying ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <ShieldCheck className="size-4" />
+          )}
+        </button>
+
+        <ConfirmDialog
+          trigger={
+            <button
+              type="button"
+              disabled={isDeleting}
+              className="text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
+              title={t('actions.deleteKey')}
+            >
+              {isDeleting ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Trash2 className="size-4" />
+              )}
+            </button>
+          }
+          title={t('deleteDialog.title')}
+          description={t('deleteDialog.description', { label: record.label })}
+          cancelLabel={t('deleteDialog.cancelAction')}
+          confirmLabel={t('deleteDialog.confirmAction')}
+          onConfirm={handleDelete}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/business/ArenaForm.tsx
+++ b/src/components/business/ArenaForm.tsx
@@ -1,14 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import {
-  ChevronDown,
-  ChevronUp,
-  Loader2,
-  Swords,
-  Upload,
-  X,
-} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Loader2, Swords, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 
 import {
@@ -18,25 +11,26 @@ import {
   IMAGE_SIZES,
   type AspectRatio,
 } from '@/constants/config'
-import {
-  getModelById,
-  getModelMessageKey,
-  isBuiltInModel,
-  MODEL_OPTIONS,
-} from '@/constants/models'
+import { getModelById, isBuiltInModel, MODEL_OPTIONS } from '@/constants/models'
 import { getProviderLabel } from '@/constants/providers'
 import type {
   ApiKeyHealthStatus,
   ArenaModelSelection,
   UserApiKeyRecord,
 } from '@/types'
+
 import type { StudioModelOption } from '@/components/business/ModelSelector'
 import { ReverseEngineerPanel } from '@/components/business/ReverseEngineerPanel'
+import { AspectRatioSelector } from '@/components/ui/aspect-ratio-selector'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { CollapsiblePanel } from '@/components/ui/collapsible-panel'
+import { ImageDropZone } from '@/components/ui/image-drop-zone'
 import { Textarea } from '@/components/ui/textarea'
 import { useApiKeysContext } from '@/contexts/api-keys-context'
 import type { StartBattleInput } from '@/hooks/use-arena'
+import { useImageUpload } from '@/hooks/use-image-upload'
+import { getTranslatedModelLabel } from '@/lib/model-options'
 import { cn } from '@/lib/utils'
 
 interface ArenaFormProps {
@@ -67,7 +61,7 @@ function buildModelOptions(
 ): ArenaModelOption[] {
   const activeApiKeys = apiKeys.filter((key) => key.isActive)
 
-  // Build a map: adapterType → best health status among active keys
+  // Build a map: adapterType -> best health status among active keys
   const adapterBestStatus = new Map<string, ModelKeyStatus>()
   for (const key of activeApiKeys) {
     const status = healthToKeyStatus(healthMap[key.id])
@@ -146,16 +140,6 @@ const STATUS_DOT_CLASSES: Record<ModelKeyStatus, string> = {
   unavailable: 'bg-red-500',
 }
 
-function getModelLabel(
-  modelId: string,
-  tModels: (key: string) => string,
-): string {
-  if (isBuiltInModel(modelId)) {
-    return tModels(`${getModelMessageKey(modelId)}.label`)
-  }
-  return modelId
-}
-
 export function ArenaForm({ isCreating, onBattle }: ArenaFormProps) {
   const t = useTranslations('ArenaPage')
   const tModels = useTranslations('Models')
@@ -171,43 +155,45 @@ export function ArenaForm({ isCreating, onBattle }: ArenaFormProps) {
     }
   }, [apiKeys, healthMap, verify])
 
-  const modelOptions = useMemo(
-    () => buildModelOptions(apiKeys, healthMap),
-    [apiKeys, healthMap],
-  )
-
-  // Deselect models that are not ready (only green/ready models can be selected)
-  useEffect(() => {
-    setSelectedOptionIds((prev) => {
-      const notReadyIds = new Set(
-        modelOptions
-          .filter((opt) => opt.keyStatus !== 'ready')
-          .map((opt) => opt.optionId),
-      )
-      if (notReadyIds.size === 0) return prev
-
-      const next = new Set<string>()
-      for (const id of prev) {
-        if (!notReadyIds.has(id)) {
-          next.add(id)
-        }
-      }
-      return next.size === prev.size ? prev : next
-    })
-  }, [modelOptions])
-
   const [prompt, setPrompt] = useState('')
   const [aspectRatio, setAspectRatio] =
     useState<AspectRatio>(DEFAULT_ASPECT_RATIO)
   const [selectedOptionIds, setSelectedOptionIds] = useState<Set<string>>(
     () => new Set(),
   )
-  const [showModelPanel, setShowModelPanel] = useState(false)
-  const [referenceImage, setReferenceImage] = useState<string | undefined>()
-  const [showReferencePanel, setShowReferencePanel] = useState(false)
-  const [showReversePanel, setShowReversePanel] = useState(false)
-  const [isDragging, setIsDragging] = useState(false)
-  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const modelOptions = useMemo(
+    () => buildModelOptions(apiKeys, healthMap),
+    [apiKeys, healthMap],
+  )
+
+  // Filter out not-ready models from selection (derived state, no useEffect needed)
+  const readyOptionIds = useMemo(() => {
+    const readyIds = new Set(
+      modelOptions
+        .filter((opt) => opt.keyStatus === 'ready')
+        .map((opt) => opt.optionId),
+    )
+    const filtered = new Set<string>()
+    for (const id of selectedOptionIds) {
+      if (readyIds.has(id)) {
+        filtered.add(id)
+      }
+    }
+    return filtered
+  }, [modelOptions, selectedOptionIds])
+
+  const {
+    referenceImage,
+    isDragging,
+    fileInputRef,
+    handleDrop,
+    handleDragOver,
+    handleDragLeave,
+    openFilePicker,
+    handleInputChange,
+    clearImage,
+  } = useImageUpload()
 
   const toggleModel = useCallback((optionId: string) => {
     setSelectedOptionIds((prev) => {
@@ -222,39 +208,11 @@ export function ArenaForm({ isCreating, onBattle }: ArenaFormProps) {
   }, [])
 
   const selectedModels: ArenaModelSelection[] = modelOptions
-    .filter((opt) => selectedOptionIds.has(opt.optionId))
+    .filter((opt) => readyOptionIds.has(opt.optionId))
     .map((opt) => ({
       modelId: opt.modelId,
       apiKeyId: opt.keyId,
     }))
-
-  const loadImageAsBase64 = useCallback((file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(reader.result as string)
-      reader.onerror = reject
-      reader.readAsDataURL(file)
-    })
-  }, [])
-
-  const handleFileChange = useCallback(
-    async (file: File) => {
-      if (!file.type.startsWith('image/')) return
-      const base64 = await loadImageAsBase64(file)
-      setReferenceImage(base64)
-    },
-    [loadImageAsBase64],
-  )
-
-  const handleDrop = useCallback(
-    async (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault()
-      setIsDragging(false)
-      const file = e.dataTransfer.files[0]
-      if (file) await handleFileChange(file)
-    },
-    [handleFileChange],
-  )
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -269,151 +227,127 @@ export function ArenaForm({ isCreating, onBattle }: ArenaFormProps) {
 
   const canBattle = prompt.trim().length > 0 && selectedModels.length >= 2
 
+  const aspectRatioOptions = (Object.keys(IMAGE_SIZES) as AspectRatio[]).map(
+    (ratio) => ({
+      value: ratio,
+      label: IMAGE_SIZES[ratio].label,
+    }),
+  )
+
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      {/* ── Model Selection (collapsible) ─────────────────── */}
-      <div className="rounded-2xl border border-border/70 bg-background/46 p-4">
-        <button
-          type="button"
-          onClick={() => setShowModelPanel((v) => !v)}
-          className="flex w-full items-center justify-between gap-4 text-left"
-        >
-          <div className="space-y-0.5">
-            <p className="text-sm font-semibold text-foreground">
-              {t('modelSelectLabel')}
-            </p>
-            <p className="font-serif text-xs text-muted-foreground">
-              {t('modelSelectCount', { count: selectedModels.length })}
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            {selectedModels.length < 2 && (
-              <Badge
-                variant="destructive"
-                className="rounded-full px-2 py-0 text-[11px]"
+      {/* Model Selection */}
+      <CollapsiblePanel
+        title={t('modelSelectLabel')}
+        description={t('modelSelectCount', { count: selectedModels.length })}
+        badge={
+          selectedModels.length < 2 ? (
+            <Badge
+              variant="destructive"
+              className="rounded-full px-2 py-0 text-[11px]"
+            >
+              {t('modelSelectMinimum')}
+            </Badge>
+          ) : undefined
+        }
+      >
+        <div className="grid gap-2 sm:grid-cols-2">
+          {modelOptions.map((option) => {
+            const isSelected = readyOptionIds.has(option.optionId)
+            const label = getTranslatedModelLabel(tModels, option.modelId)
+            const provider = getProviderLabel(option.providerConfig)
+
+            return (
+              <button
+                key={option.optionId}
+                type="button"
+                onClick={() => toggleModel(option.optionId)}
+                disabled={isCreating || option.keyStatus !== 'ready'}
+                className={cn(
+                  'flex items-center gap-3 rounded-2xl border px-4 py-3 text-left transition-all',
+                  option.keyStatus !== 'ready' &&
+                    'cursor-not-allowed opacity-50',
+                  isSelected
+                    ? 'border-primary/60 bg-primary/5 ring-1 ring-primary/20'
+                    : 'border-border/75 bg-background/72 hover:border-border',
+                )}
               >
-                {t('modelSelectMinimum')}
-              </Badge>
-            )}
-            {showModelPanel ? (
-              <ChevronUp className="size-4 text-muted-foreground" />
-            ) : (
-              <ChevronDown className="size-4 text-muted-foreground" />
-            )}
-          </div>
-        </button>
-
-        {showModelPanel && (
-          <div className="mt-4 grid gap-2 border-t border-border/70 pt-4 sm:grid-cols-2">
-            {modelOptions.map((option) => {
-              const isSelected = selectedOptionIds.has(option.optionId)
-              const label = getModelLabel(option.modelId, tModels)
-              const provider = getProviderLabel(option.providerConfig)
-
-              return (
-                <button
-                  key={option.optionId}
-                  type="button"
-                  onClick={() => toggleModel(option.optionId)}
-                  disabled={isCreating || option.keyStatus !== 'ready'}
+                {/* Checkbox */}
+                <div
                   className={cn(
-                    'flex items-center gap-3 rounded-2xl border px-4 py-3 text-left transition-all',
-                    option.keyStatus !== 'ready' &&
-                      'cursor-not-allowed opacity-50',
+                    'flex size-5 shrink-0 items-center justify-center rounded-md border-2 transition-colors',
                     isSelected
-                      ? 'border-primary/60 bg-primary/5 ring-1 ring-primary/20'
-                      : 'border-border/75 bg-background/72 hover:border-border',
+                      ? 'border-primary bg-primary text-primary-foreground'
+                      : 'border-muted-foreground/40',
                   )}
                 >
-                  {/* Checkbox */}
-                  <div
-                    className={cn(
-                      'flex size-5 shrink-0 items-center justify-center rounded-md border-2 transition-colors',
-                      isSelected
-                        ? 'border-primary bg-primary text-primary-foreground'
-                        : 'border-muted-foreground/40',
-                    )}
-                  >
-                    {isSelected && (
-                      <svg
-                        className="size-3"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={3}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M5 13l4 4L19 7"
-                        />
-                      </svg>
-                    )}
-                  </div>
-
-                  {/* Model info */}
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-medium text-foreground">
-                      {label}
-                    </p>
-                    <p className="truncate text-xs text-muted-foreground">
-                      {provider}
-                    </p>
-                  </div>
-
-                  {/* Status dot + badge */}
-                  <div className="flex shrink-0 items-center gap-2">
-                    <span
-                      className={cn(
-                        'size-2.5 rounded-full',
-                        STATUS_DOT_CLASSES[option.keyStatus],
-                      )}
-                      title={t(`keyStatus.${option.keyStatus}`)}
-                    />
-                    <Badge
-                      variant={
-                        option.sourceType === 'saved' ? 'secondary' : 'outline'
-                      }
-                      className="rounded-full px-2 py-0 text-[11px]"
+                  {isSelected && (
+                    <svg
+                      className="size-3"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={3}
                     >
-                      {option.sourceType === 'saved'
-                        ? t('modelBadgeSaved')
-                        : t('modelBadgeWorkspace')}
-                    </Badge>
-                  </div>
-                </button>
-              )
-            })}
-          </div>
-        )}
-      </div>
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  )}
+                </div>
 
-      {/* ── Aspect Ratio ───────────────────────────────────── */}
+                {/* Model info */}
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-foreground">
+                    {label}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {provider}
+                  </p>
+                </div>
+
+                {/* Status dot + badge */}
+                <div className="flex shrink-0 items-center gap-2">
+                  <span
+                    className={cn(
+                      'size-2.5 rounded-full',
+                      STATUS_DOT_CLASSES[option.keyStatus],
+                    )}
+                    title={t(`keyStatus.${option.keyStatus}`)}
+                  />
+                  <Badge
+                    variant={
+                      option.sourceType === 'saved' ? 'secondary' : 'outline'
+                    }
+                    className="rounded-full px-2 py-0 text-[11px]"
+                  >
+                    {option.sourceType === 'saved'
+                      ? t('modelBadgeSaved')
+                      : t('modelBadgeWorkspace')}
+                  </Badge>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </CollapsiblePanel>
+
+      {/* Aspect Ratio */}
       <div className="space-y-2">
         <label className="text-sm font-semibold text-foreground">
           {t('aspectRatioLabel')}
         </label>
-        <div className="flex flex-wrap gap-2">
-          {(Object.keys(IMAGE_SIZES) as AspectRatio[]).map((ratio) => (
-            <button
-              key={ratio}
-              type="button"
-              onClick={() => setAspectRatio(ratio)}
-              disabled={isCreating}
-              className={cn(
-                'rounded-full border px-4 py-1.5 text-sm font-medium transition-colors',
-                ratio === aspectRatio
-                  ? 'border-primary bg-primary/10 text-primary'
-                  : 'border-border/75 text-muted-foreground hover:border-border hover:text-foreground',
-              )}
-            >
-              {IMAGE_SIZES[ratio].label}
-            </button>
-          ))}
-        </div>
+        <AspectRatioSelector
+          options={aspectRatioOptions}
+          value={aspectRatio}
+          onChange={(v) => setAspectRatio(v as AspectRatio)}
+          disabled={isCreating}
+        />
       </div>
 
-      {/* ── Prompt ─────────────────────────────────────────── */}
+      {/* Prompt */}
       <div className="space-y-2">
         <label
           htmlFor="arena-prompt"
@@ -433,133 +367,69 @@ export function ArenaForm({ isCreating, onBattle }: ArenaFormProps) {
         />
       </div>
 
-      {/* ── Reference Image ────────────────────────────────── */}
-      <div className="rounded-2xl border border-border/70 bg-background/46 p-4">
-        <button
-          type="button"
-          onClick={() => setShowReferencePanel((v) => !v)}
-          className="flex w-full items-center justify-between gap-4 text-left"
-        >
-          <div className="space-y-0.5">
-            <p className="text-sm font-semibold text-foreground">
-              {t('referenceTitle')}
-            </p>
-            <p className="font-serif text-xs text-muted-foreground">
-              {referenceImage ? t('referenceSelected') : t('referenceIdle')}
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            {referenceImage && (
-              <Badge variant="secondary" className="rounded-full px-3 py-1">
-                {t('referenceBadge')}
-              </Badge>
-            )}
-            {showReferencePanel ? (
-              <ChevronUp className="size-4 text-muted-foreground" />
-            ) : (
-              <ChevronDown className="size-4 text-muted-foreground" />
-            )}
-          </div>
-        </button>
-
-        {showReferencePanel && (
-          <div className="mt-4 border-t border-border/70 pt-4">
-            {referenceImage ? (
-              <div className="relative inline-flex overflow-hidden rounded-2xl border border-border/75 bg-background">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={referenceImage}
-                  alt={t('referencePreviewAlt')}
-                  className="h-36 w-auto object-cover"
-                />
-                <button
-                  type="button"
-                  onClick={() => setReferenceImage(undefined)}
-                  className="absolute right-3 top-3 rounded-full border border-border/75 bg-background/92 p-1.5 text-muted-foreground transition-colors hover:text-destructive"
-                  aria-label={t('referenceRemoveLabel')}
-                >
-                  <X className="size-3.5" />
-                </button>
-              </div>
-            ) : (
-              <div
-                role="button"
-                tabIndex={0}
-                onDragOver={(e) => {
-                  e.preventDefault()
-                  setIsDragging(true)
-                }}
-                onDragLeave={() => setIsDragging(false)}
-                onDrop={handleDrop}
-                onClick={() => fileInputRef.current?.click()}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    fileInputRef.current?.click()
-                  }
-                }}
-                className={cn(
-                  'flex cursor-pointer flex-col items-center gap-2 rounded-2xl border-2 border-dashed px-6 py-8 text-center transition-colors',
-                  isDragging
-                    ? 'border-primary/60 bg-primary/5'
-                    : 'border-border/80 bg-background/72 hover:border-primary/40 hover:bg-secondary/18',
-                )}
-              >
-                <Upload className="size-5 text-muted-foreground" />
-                <p className="text-sm font-medium text-foreground">
-                  {t('referenceUpload')}
-                </p>
-                <p className="font-serif text-xs text-muted-foreground">
-                  {t('referenceFormats')}
-                </p>
-              </div>
-            )}
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              className="hidden"
-              onChange={async (e) => {
-                const file = e.target.files?.[0]
-                if (file) await handleFileChange(file)
-              }}
+      {/* Reference Image */}
+      <CollapsiblePanel
+        title={t('referenceTitle')}
+        description={
+          referenceImage ? t('referenceSelected') : t('referenceIdle')
+        }
+        badge={
+          referenceImage ? (
+            <Badge variant="secondary" className="rounded-full px-3 py-1">
+              {t('referenceBadge')}
+            </Badge>
+          ) : undefined
+        }
+      >
+        {referenceImage ? (
+          <div className="relative inline-flex overflow-hidden rounded-2xl border border-border/75 bg-background">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={referenceImage}
+              alt={t('referencePreviewAlt')}
+              className="h-36 w-auto object-cover"
             />
+            <button
+              type="button"
+              onClick={clearImage}
+              className="absolute right-3 top-3 rounded-full border border-border/75 bg-background/92 p-1.5 text-muted-foreground transition-colors hover:text-destructive"
+              aria-label={t('referenceRemoveLabel')}
+            >
+              <X className="size-3.5" />
+            </button>
           </div>
+        ) : (
+          <ImageDropZone
+            isDragging={isDragging}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onClick={openFilePicker}
+            uploadLabel={t('referenceUpload')}
+            formatsLabel={t('referenceFormats')}
+          />
         )}
-      </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleInputChange}
+        />
+      </CollapsiblePanel>
 
-      {/* ── Reverse Engineer ───────────────────────────────── */}
-      <div className="rounded-2xl border border-border/70 bg-background/46 p-4">
-        <button
-          type="button"
-          onClick={() => setShowReversePanel((v) => !v)}
-          className="flex w-full items-center justify-between gap-4 text-left"
-        >
-          <div className="space-y-0.5">
-            <p className="text-sm font-semibold text-foreground">
-              {t('reverseTitle')}
-            </p>
-            <p className="font-serif text-xs text-muted-foreground">
-              {t('reverseDescription')}
-            </p>
-          </div>
-          {showReversePanel ? (
-            <ChevronUp className="size-4 text-muted-foreground" />
-          ) : (
-            <ChevronDown className="size-4 text-muted-foreground" />
-          )}
-        </button>
+      {/* Reverse Engineer */}
+      <CollapsiblePanel
+        title={t('reverseTitle')}
+        description={t('reverseDescription')}
+      >
+        <ReverseEngineerPanel
+          onUsePrompt={(generatedPrompt) => setPrompt(generatedPrompt)}
+          selectedModels={selectedModels}
+        />
+      </CollapsiblePanel>
 
-        {showReversePanel && (
-          <div className="mt-4 border-t border-border/70 pt-4">
-            <ReverseEngineerPanel
-              onUsePrompt={(generatedPrompt) => setPrompt(generatedPrompt)}
-              selectedModels={selectedModels}
-            />
-          </div>
-        )}
-      </div>
-
-      {/* ── Submit ─────────────────────────────────────────── */}
+      {/* Submit */}
       <Button
         type="submit"
         size="lg"

--- a/src/components/business/GenerateForm.tsx
+++ b/src/components/business/GenerateForm.tsx
@@ -1,21 +1,11 @@
 'use client'
 
-import { useCallback, useRef, useState } from 'react'
-import {
-  AlertCircle,
-  ChevronDown,
-  ChevronUp,
-  ImageIcon,
-  Loader2,
-  Sparkles,
-  Upload,
-  X,
-} from 'lucide-react'
+import { useState } from 'react'
+import { ImageIcon, Loader2, Sparkles, X } from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl'
 
 import {
   API_USAGE,
-  DEFAULT_ASPECT_RATIO,
   GENERATION_LIMITS,
   IMAGE_SIZES,
   type AspectRatio,
@@ -33,68 +23,66 @@ import {
   ModelSelector,
   type StudioModelOption,
 } from '@/components/business/ModelSelector'
-import { PromptEnhanceButton } from '@/components/business/PromptEnhanceButton'
-import { PromptComparisonPanel } from '@/components/business/PromptComparisonPanel'
+import { PromptEnhancer } from '@/components/business/PromptEnhancer'
 import { ReverseEngineerPanel } from '@/components/business/ReverseEngineerPanel'
+import { AspectRatioSelector } from '@/components/ui/aspect-ratio-selector'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { CollapsiblePanel } from '@/components/ui/collapsible-panel'
+import { ErrorAlert } from '@/components/ui/error-alert'
+import { ImageDropZone } from '@/components/ui/image-drop-zone'
 import { Textarea } from '@/components/ui/textarea'
 import { useApiKeysContext } from '@/contexts/api-keys-context'
 import { useGenerateImage } from '@/hooks/use-generate'
-import { usePromptEnhance } from '@/hooks/use-prompt-enhance'
+import { useGenerationForm } from '@/hooks/use-generation-form'
+import {
+  buildSavedModelOptions,
+  findSelectedModel,
+  getTranslatedModelLabel,
+} from '@/lib/model-options'
 import { cn } from '@/lib/utils'
 
-type MessageGetter = (
-  key: string,
-  values?: Record<string, string | number>,
-) => string
-
-function getTranslatedModelLabel(
-  tModels: MessageGetter,
-  modelId: string,
-): string {
-  if (isBuiltInModel(modelId)) {
-    return tModels(`${getModelMessageKey(modelId)}.label`)
-  }
-
-  return modelId
-}
-
 function getTranslatedModelDescription(
-  t: MessageGetter,
-  tModels: MessageGetter,
+  t: (key: string, values?: Record<string, string | number>) => string,
+  tModels: (key: string, values?: Record<string, string | number>) => string,
   model: StudioModelOption,
 ): string {
   if (isBuiltInModel(model.modelId)) {
     return tModels(`${getModelMessageKey(model.modelId)}.description`)
   }
-
   return t('modelCustomDescription', {
     provider: getProviderLabel(model.providerConfig),
   })
 }
 
 export function GenerateForm() {
-  const [prompt, setPrompt] = useState('')
   const [selectedOptionId, setSelectedOptionId] = useState<string>(
     `workspace:${AI_MODELS.GEMINI_FLASH_IMAGE}`,
   )
-  const [aspectRatio, setAspectRatio] =
-    useState<AspectRatio>(DEFAULT_ASPECT_RATIO)
-  const [referenceImage, setReferenceImage] = useState<string | undefined>()
-  const [showReferencePanel, setShowReferencePanel] = useState(false)
-  const [isDragging, setIsDragging] = useState(false)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const { isGenerating, error, generatedGeneration, generate } =
-    useGenerateImage()
   const {
+    prompt,
+    setPrompt,
+    aspectRatio,
+    setAspectRatio,
+    referenceImage,
+    isDragging,
+    fileInputRef,
+    handleDrop,
+    handleDragOver,
+    handleDragLeave,
+    openFilePicker,
+    handleInputChange,
+    clearImage,
     isEnhancing,
     enhanced,
-    original: enhancedOriginal,
-    style: enhancedStyle,
-    enhance: enhancePrompt,
+    enhancedOriginal,
+    enhancedStyle,
+    enhancePrompt,
     clearEnhancement,
-  } = usePromptEnhance()
+    applyEnhancedPrompt,
+  } = useGenerationForm()
+  const { isGenerating, error, generatedGeneration, generate } =
+    useGenerateImage()
   const { keys: apiKeys, healthMap } = useApiKeysContext()
   const locale = useLocale()
   const isDenseLocale = isCjkLocale(locale)
@@ -103,14 +91,12 @@ export function GenerateForm() {
   const tModels = useTranslations('Models')
   const activeApiKeys = apiKeys.filter((key) => key.isActive)
 
-  // Adapter types that have at least one verified (available) API key
   const verifiedAdapterTypes = new Set(
     activeApiKeys
       .filter((key) => healthMap[key.id] === 'available')
       .map((key) => key.adapterType),
   )
 
-  // Built-in models: only show free tier when no verified keys for that adapter
   const builtInOptions: StudioModelOption[] = MODEL_OPTIONS.filter(
     (model) => model.freeTier || verifiedAdapterTypes.has(model.adapterType),
   ).map((model) => ({
@@ -123,62 +109,20 @@ export function GenerateForm() {
     freeTier: model.freeTier,
     sourceType: 'workspace',
   }))
-  const savedOptions: StudioModelOption[] = activeApiKeys
-    .filter((key) => healthMap[key.id] === 'available')
-    .map((key) => ({
-      optionId: `key:${key.id}`,
-      modelId: key.modelId,
-      adapterType: key.adapterType,
-      providerConfig: key.providerConfig,
-      requestCount: API_USAGE.DEFAULT_REQUESTS_PER_GENERATION,
-      isBuiltIn: isBuiltInModel(key.modelId),
-      sourceType: 'saved',
-      keyId: key.id,
-      keyLabel: key.label,
-      maskedKey: key.maskedKey,
-    }))
+  const savedOptions = buildSavedModelOptions(
+    activeApiKeys,
+    (key) => healthMap[key.id] === 'available',
+  )
   const modelOptions = [...builtInOptions, ...savedOptions]
-  const selectedModel =
-    modelOptions.find((option) => option.optionId === selectedOptionId) ??
-    modelOptions[0]
+  const selectedModel = findSelectedModel(modelOptions, selectedOptionId)
 
   const generatedModelLabel = generatedGeneration
     ? getTranslatedModelLabel(tModels, generatedGeneration.model)
     : null
 
-  const loadImageAsBase64 = useCallback((file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(reader.result as string)
-      reader.onerror = reject
-      reader.readAsDataURL(file)
-    })
-  }, [])
-
-  const handleFileChange = useCallback(
-    async (file: File) => {
-      if (!file.type.startsWith('image/')) return
-      const base64 = await loadImageAsBase64(file)
-      setReferenceImage(base64)
-    },
-    [loadImageAsBase64],
-  )
-
-  const handleDrop = useCallback(
-    async (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault()
-      setIsDragging(false)
-      const file = e.dataTransfer.files[0]
-      if (file) await handleFileChange(file)
-    },
-    [handleFileChange],
-  )
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-
     if (!prompt.trim() || isGenerating || !selectedModel) return
-
     await generate({
       prompt: prompt.trim(),
       modelId: selectedModel.modelId,
@@ -188,9 +132,7 @@ export function GenerateForm() {
     })
   }
 
-  if (!selectedModel) {
-    return null
-  }
+  if (!selectedModel) return null
 
   const selectedModelLabel = getTranslatedModelLabel(
     tModels,
@@ -211,7 +153,6 @@ export function GenerateForm() {
             onChange={setSelectedOptionId}
             options={modelOptions}
           />
-
           <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1.5">
             <h3 className="font-display text-base font-medium tracking-tight text-foreground">
               {selectedModelLabel}
@@ -227,18 +168,16 @@ export function GenerateForm() {
                 variant="secondary"
                 className="rounded-full bg-primary/10 px-2.5 py-0.5 text-xs text-foreground"
               >
-                {tCommon('creditCount', {
-                  count: selectedModel.requestCount,
-                })}
+                {tCommon('creditCount', { count: selectedModel.requestCount })}
               </Badge>
-              {!selectedModel.isBuiltIn ? (
+              {!selectedModel.isBuiltIn && (
                 <Badge
                   variant="outline"
                   className="rounded-full border-border/70 bg-background/70 px-2.5 py-0.5 text-xs"
                 >
                   {t('customModelBadge')}
                 </Badge>
-              ) : null}
+              )}
             </div>
           </div>
           <p className="mt-1.5 font-serif text-sm leading-6 text-muted-foreground">
@@ -260,13 +199,18 @@ export function GenerateForm() {
               </p>
             </div>
             <div className="flex items-center gap-2">
-              <PromptEnhanceButton
+              <PromptEnhancer
                 prompt={prompt}
                 isEnhancing={isEnhancing}
                 disabled={isGenerating}
+                enhanced={enhanced}
+                enhancedOriginal={enhancedOriginal}
+                enhancedStyle={enhancedStyle}
                 onEnhance={(style) =>
                   enhancePrompt(prompt, style, selectedModel?.keyId)
                 }
+                onUseEnhanced={applyEnhancedPrompt}
+                onDismiss={clearEnhancement}
               />
               <p className="text-xs font-medium text-muted-foreground">
                 {t('promptCounter', {
@@ -291,116 +235,61 @@ export function GenerateForm() {
             />
           </div>
 
-          {enhanced && enhancedOriginal && enhancedStyle && (
-            <PromptComparisonPanel
-              original={enhancedOriginal}
-              enhanced={enhanced}
-              style={enhancedStyle}
-              onUseEnhanced={(text) => {
-                setPrompt(text)
-                clearEnhancement()
-              }}
-              onDismiss={clearEnhancement}
-            />
-          )}
-
-          <div className="mt-5 rounded-3xl border border-border/70 bg-background/46 p-4">
-            <button
-              type="button"
-              onClick={() => setShowReferencePanel((value) => !value)}
-              className="flex w-full items-center justify-between gap-4 text-left"
-            >
-              <div className="space-y-1">
-                <p className="text-sm font-semibold text-foreground">
-                  {t('referenceTitle')}
-                </p>
-                <p className="font-serif text-sm leading-6 text-muted-foreground">
-                  {referenceImage
-                    ? t('referenceSelectedDescription')
-                    : t('referenceIdleDescription')}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                {referenceImage ? (
+          <div className="mt-5">
+            <CollapsiblePanel
+              title={t('referenceTitle')}
+              description={
+                referenceImage
+                  ? t('referenceSelectedDescription')
+                  : t('referenceIdleDescription')
+              }
+              badge={
+                referenceImage ? (
                   <Badge variant="secondary" className="rounded-full px-3 py-1">
                     {t('referenceBadge')}
                   </Badge>
-                ) : null}
-                {showReferencePanel ? (
-                  <ChevronUp className="size-4 text-muted-foreground" />
-                ) : (
-                  <ChevronDown className="size-4 text-muted-foreground" />
-                )}
-              </div>
-            </button>
-
-            {showReferencePanel ? (
-              <div className="mt-4 border-t border-border/70 pt-4">
-                {referenceImage ? (
-                  <div className="relative inline-flex overflow-hidden rounded-2xl border border-border/75 bg-background">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img
-                      src={referenceImage}
-                      alt={t('referencePreviewAlt')}
-                      className="h-36 w-auto object-cover"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setReferenceImage(undefined)}
-                      className="absolute right-3 top-3 rounded-full border border-border/75 bg-background/92 p-1.5 text-muted-foreground transition-colors hover:text-destructive"
-                      aria-label={t('referenceRemoveLabel')}
-                    >
-                      <X className="size-3.5" />
-                    </button>
-                  </div>
-                ) : (
-                  <div
-                    role="button"
-                    tabIndex={0}
-                    onDragOver={(e) => {
-                      e.preventDefault()
-                      setIsDragging(true)
-                    }}
-                    onDragLeave={() => setIsDragging(false)}
-                    onDrop={handleDrop}
-                    onClick={() => fileInputRef.current?.click()}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        fileInputRef.current?.click()
-                      }
-                    }}
-                    className={cn(
-                      'flex cursor-pointer flex-col items-center gap-2 rounded-2xl border-2 border-dashed px-6 py-10 text-center transition-colors',
-                      isDragging
-                        ? 'border-primary/50 bg-primary/5'
-                        : 'border-border/60 bg-background/60 hover:border-primary/30 hover:bg-primary/3',
-                    )}
+                ) : undefined
+              }
+            >
+              {referenceImage ? (
+                <div className="relative inline-flex overflow-hidden rounded-2xl border border-border/75 bg-background">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={referenceImage}
+                    alt={t('referencePreviewAlt')}
+                    className="h-36 w-auto object-cover"
+                  />
+                  <button
+                    type="button"
+                    onClick={clearImage}
+                    className="absolute right-3 top-3 rounded-full border border-border/75 bg-background/92 p-1.5 text-muted-foreground transition-colors hover:text-destructive"
+                    aria-label={t('referenceRemoveLabel')}
                   >
-                    <Upload className="size-5 text-muted-foreground" />
-                    <p className="text-sm font-medium text-foreground">
-                      {t('referenceUploadAction')}
-                    </p>
-                    <p className="font-serif text-xs text-muted-foreground">
-                      {t('referenceUploadFormats')}
-                    </p>
-                  </div>
-                )}
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*"
-                  aria-label={t('referenceImageLabel')}
-                  className="hidden"
-                  onChange={async (e) => {
-                    const file = e.target.files?.[0]
-                    if (file) await handleFileChange(file)
-                  }}
+                    <X className="size-3.5" />
+                  </button>
+                </div>
+              ) : (
+                <ImageDropZone
+                  isDragging={isDragging}
+                  onDrop={handleDrop}
+                  onDragOver={handleDragOver}
+                  onDragLeave={handleDragLeave}
+                  onClick={openFilePicker}
+                  uploadLabel={t('referenceUploadAction')}
+                  formatsLabel={t('referenceUploadFormats')}
                 />
-              </div>
-            ) : null}
+              )}
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                aria-label={t('referenceImageLabel')}
+                className="hidden"
+                onChange={handleInputChange}
+              />
+            </CollapsiblePanel>
           </div>
 
-          {/* Aspect Ratio Selector */}
           <div className="mt-5 rounded-2xl border border-border/50 bg-background/40 p-4">
             <p
               className={cn(
@@ -412,26 +301,13 @@ export function GenerateForm() {
             >
               {t('aspectRatioLabel')}
             </p>
-            <div className="flex flex-wrap gap-2">
-              {(Object.keys(IMAGE_SIZES) as AspectRatio[]).map((ar) => (
-                <button
-                  key={ar}
-                  type="button"
-                  onClick={() => setAspectRatio(ar)}
-                  className={cn(
-                    'rounded-full px-4 py-2 text-sm font-medium transition-colors',
-                    aspectRatio === ar
-                      ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/20'
-                      : 'border border-border/60 bg-background/50 text-foreground hover:bg-primary/5 hover:border-primary/20',
-                  )}
-                >
-                  {ar}
-                </button>
-              ))}
-            </div>
+            <AspectRatioSelector
+              options={Object.keys(IMAGE_SIZES) as AspectRatio[]}
+              value={aspectRatio}
+              onChange={setAspectRatio}
+            />
           </div>
 
-          {/* Reverse Engineer Panel */}
           <div className="mt-5 rounded-2xl border border-border/50 bg-background/40 p-4">
             <ReverseEngineerPanel
               selectedModels={
@@ -466,7 +342,6 @@ export function GenerateForm() {
               {t('ctaSectionDescription')}
             </p>
           </div>
-
           <Button
             type="submit"
             size="lg"
@@ -489,37 +364,32 @@ export function GenerateForm() {
         </div>
       </section>
 
-      {error ? (
-        <div className="flex items-start gap-3 rounded-2xl border border-destructive/25 bg-destructive/5 p-4 text-sm text-destructive">
-          <AlertCircle className="mt-0.5 size-4 shrink-0" />
-          <div className="space-y-1">
-            <p className="font-medium">{t('errorTitle')}</p>
-            <p>{error}</p>
-            {(error.includes('Free tier limit') ||
-              error.includes('bind your own API key') ||
-              error.includes('API key')) && (
-              <div className="mt-2 space-y-1 text-xs text-muted-foreground">
-                <p className="font-medium text-foreground">
-                  {t('freeQuotaGuide.title')}
-                </p>
-                <ol className="list-inside list-decimal space-y-0.5">
-                  <li>
-                    <a
-                      href="https://aistudio.google.com/apikey"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary underline underline-offset-2 hover:text-primary/80"
-                    >
-                      {t('freeQuotaGuide.step1')}
-                    </a>
-                  </li>
-                  <li>{t('freeQuotaGuide.step2')}</li>
-                </ol>
-              </div>
-            )}
-          </div>
-        </div>
-      ) : null}
+      {error && (
+        <ErrorAlert title={t('errorTitle')} message={error}>
+          {(error.includes('Free tier limit') ||
+            error.includes('bind your own API key') ||
+            error.includes('API key')) && (
+            <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+              <p className="font-medium text-foreground">
+                {t('freeQuotaGuide.title')}
+              </p>
+              <ol className="list-inside list-decimal space-y-0.5">
+                <li>
+                  <a
+                    href="https://aistudio.google.com/apikey"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline underline-offset-2 hover:text-primary/80"
+                  >
+                    {t('freeQuotaGuide.step1')}
+                  </a>
+                </li>
+                <li>{t('freeQuotaGuide.step2')}</li>
+              </ol>
+            </div>
+          )}
+        </ErrorAlert>
+      )}
 
       <section className="space-y-3">
         <div className="space-y-1">
@@ -546,7 +416,6 @@ export function GenerateForm() {
               alt={generatedGeneration.prompt}
               className="h-auto w-full object-cover"
             />
-
             <div className="space-y-4 border-t border-border/75 p-5 sm:p-6">
               <div className="space-y-2">
                 <p
@@ -563,7 +432,6 @@ export function GenerateForm() {
                   {generatedGeneration.prompt}
                 </p>
               </div>
-
               <div className="flex flex-wrap gap-2">
                 <Badge
                   variant="outline"
@@ -587,11 +455,9 @@ export function GenerateForm() {
                   })}
                 </Badge>
               </div>
-
               <p className="font-serif text-sm text-muted-foreground">
                 {t('resultStorageNote')}
               </p>
-
               {selectedModel?.freeTier &&
                 selectedModel.sourceType === 'workspace' && (
                   <p className="font-serif text-xs text-muted-foreground/70">

--- a/src/components/business/HomepageFeatures.tsx
+++ b/src/components/business/HomepageFeatures.tsx
@@ -1,0 +1,60 @@
+import type { LucideIcon } from 'lucide-react'
+import { Archive, ShieldCheck, Sparkles } from 'lucide-react'
+import { useLocale, useTranslations } from 'next-intl'
+
+import {
+  HOMEPAGE_FEATURES,
+  type HomepageFeatureIcon,
+} from '@/constants/homepage'
+import { isCjkLocale } from '@/i18n/routing'
+import { cn } from '@/lib/utils'
+
+import styles from './HomepageShell.module.css'
+
+const featureIcons: Record<HomepageFeatureIcon, LucideIcon> = {
+  sparkles: Sparkles,
+  archive: Archive,
+  shield: ShieldCheck,
+}
+
+export function HomepageFeatures() {
+  const locale = useLocale()
+  const isDenseLocale = isCjkLocale(locale)
+  const t = useTranslations('Homepage')
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.sectionIntro}>
+        <p
+          className={cn(styles.sectionLabel, isDenseLocale && styles.denseCopy)}
+        >
+          {t('features.eyebrow')}
+        </p>
+        <h2 className={styles.sectionTitle}>{t('features.title')}</h2>
+        <p className={styles.sectionDescription}>{t('features.description')}</p>
+      </div>
+
+      <div className={styles.featureGrid}>
+        {HOMEPAGE_FEATURES.map((feature) => {
+          const FeatureIcon = featureIcons[feature.icon]
+
+          return (
+            <article key={feature.id} className={styles.featureItem}>
+              <div className={styles.featureHeader}>
+                <span className={styles.featureIcon}>
+                  <FeatureIcon className="size-5" />
+                </span>
+                <h3 className={styles.featureTitle}>
+                  {t(`features.items.${feature.id}.title`)}
+                </h3>
+              </div>
+              <p className={styles.featureDescription}>
+                {t(`features.items.${feature.id}.description`)}
+              </p>
+            </article>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/business/HomepageHero.tsx
+++ b/src/components/business/HomepageHero.tsx
@@ -1,0 +1,138 @@
+import { ArrowRight } from 'lucide-react'
+import { useLocale, useTranslations } from 'next-intl'
+
+import { API_USAGE } from '@/constants/config'
+import { HOMEPAGE_SCENES } from '@/constants/homepage'
+import { MODEL_OPTIONS } from '@/constants/models'
+import { Button } from '@/components/ui/button'
+import { Link } from '@/i18n/navigation'
+import { isCjkLocale } from '@/i18n/routing'
+import { cn } from '@/lib/utils'
+
+import { HomepageSceneCard } from './HomepageSceneCard'
+import styles from './HomepageShell.module.css'
+
+const providerCount = new Set(MODEL_OPTIONS.map((model) => model.adapterType))
+  .size
+
+const HERO_SCENE_COUNT = 2
+
+interface HomepageHeroProps {
+  eyebrow: string
+  title: string
+  description: string
+  primaryActionHref: string
+  primaryActionLabel: string
+  secondaryActionHref: string
+  secondaryActionLabel: string
+}
+
+export function HomepageHero({
+  eyebrow,
+  title,
+  description,
+  primaryActionHref,
+  primaryActionLabel,
+  secondaryActionHref,
+  secondaryActionLabel,
+}: HomepageHeroProps) {
+  const locale = useLocale()
+  const isDenseLocale = isCjkLocale(locale)
+  const t = useTranslations('Homepage')
+  const tCommon = useTranslations('Common')
+
+  return (
+    <section className={styles.hero}>
+      <div className={styles.heroGrid}>
+        <div className={styles.heroCopy}>
+          <p className={cn(styles.eyebrow, isDenseLocale && styles.denseCopy)}>
+            {eyebrow}
+          </p>
+          <h1 className={styles.title}>{title}</h1>
+          <p className={styles.description}>{description}</p>
+
+          <div className={styles.actions}>
+            <Button asChild size="lg" className={styles.primaryButton}>
+              <Link href={primaryActionHref}>
+                {primaryActionLabel}
+                <ArrowRight className="size-4" />
+              </Link>
+            </Button>
+
+            <Button
+              asChild
+              variant="outline"
+              size="lg"
+              className={styles.secondaryButton}
+            >
+              <Link href={secondaryActionHref}>{secondaryActionLabel}</Link>
+            </Button>
+          </div>
+        </div>
+
+        <div className={styles.heroVisual}>
+          <div className={styles.heroVisualInner}>
+            {HOMEPAGE_SCENES.slice(0, HERO_SCENE_COUNT).map((scene) => (
+              <HomepageSceneCard
+                key={scene.id}
+                sceneId={scene.id}
+                modelId={scene.modelId}
+                tone={scene.tone}
+                className={styles.heroVisualCard}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.heroMetrics}>
+        <div className={styles.signalItem}>
+          <span
+            className={cn(
+              styles.signalLabel,
+              isDenseLocale && styles.denseCopy,
+            )}
+          >
+            {t('signals.modelCoverageLabel')}
+          </span>
+          <span className={styles.signalValue}>
+            {t('signals.modelCoverageValue', {
+              modelCount: MODEL_OPTIONS.length,
+              providerCount,
+            })}
+          </span>
+        </div>
+        <div className={styles.signalItem}>
+          <span
+            className={cn(
+              styles.signalLabel,
+              isDenseLocale && styles.denseCopy,
+            )}
+          >
+            {t('signals.creditLabel')}
+          </span>
+          <span className={styles.signalValue}>
+            {t('signals.creditValue', {
+              creditCount: tCommon('creditCount', {
+                count: API_USAGE.DEFAULT_REQUESTS_PER_GENERATION,
+              }),
+            })}
+          </span>
+        </div>
+        <div className={styles.signalItem}>
+          <span
+            className={cn(
+              styles.signalLabel,
+              isDenseLocale && styles.denseCopy,
+            )}
+          >
+            {t('signals.archiveLabel')}
+          </span>
+          <span className={styles.signalValue}>
+            {t('signals.archiveValue')}
+          </span>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/business/HomepageModels.tsx
+++ b/src/components/business/HomepageModels.tsx
@@ -1,0 +1,67 @@
+import { useLocale, useTranslations } from 'next-intl'
+
+import { API_USAGE } from '@/constants/config'
+import { getModelMessageKey, MODEL_OPTIONS } from '@/constants/models'
+import { getProviderLabel } from '@/constants/providers'
+import { isCjkLocale } from '@/i18n/routing'
+import { cn } from '@/lib/utils'
+
+import styles from './HomepageShell.module.css'
+
+export function HomepageModels() {
+  const locale = useLocale()
+  const isDenseLocale = isCjkLocale(locale)
+  const t = useTranslations('Homepage')
+  const tCommon = useTranslations('Common')
+  const tModels = useTranslations('Models')
+
+  return (
+    <section id="models" className={styles.section}>
+      <div className={styles.sectionIntro}>
+        <p
+          className={cn(styles.sectionLabel, isDenseLocale && styles.denseCopy)}
+        >
+          {t('models.eyebrow')}
+        </p>
+        <h2 className={styles.sectionTitle}>{t('models.title')}</h2>
+        <p className={styles.sectionDescription}>{t('models.description')}</p>
+      </div>
+
+      <div className={styles.modelRail}>
+        {MODEL_OPTIONS.map((model) => (
+          <article key={model.id} className={styles.modelCard}>
+            <div>
+              <div className={styles.modelMeta}>
+                <span
+                  className={cn(
+                    styles.providerTag,
+                    isDenseLocale && styles.denseCopy,
+                  )}
+                >
+                  {getProviderLabel(model.providerConfig)}
+                </span>
+                <span
+                  className={cn(
+                    styles.costTag,
+                    isDenseLocale && styles.denseCopy,
+                  )}
+                >
+                  {tCommon('creditCount', {
+                    count: API_USAGE.DEFAULT_REQUESTS_PER_GENERATION,
+                  })}
+                </span>
+              </div>
+              <h3 className={styles.modelTitle}>
+                {tModels(`${getModelMessageKey(model.id)}.label`)}
+              </h3>
+            </div>
+
+            <p className={styles.modelDescription}>
+              {tModels(`${getModelMessageKey(model.id)}.description`)}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/business/HomepageSceneCard.tsx
+++ b/src/components/business/HomepageSceneCard.tsx
@@ -1,0 +1,51 @@
+import { useLocale, useTranslations } from 'next-intl'
+
+import type { AI_MODELS } from '@/constants/models'
+import { getModelMessageKey } from '@/constants/models'
+import type { HomepageSceneTone } from '@/constants/homepage'
+import { isCjkLocale } from '@/i18n/routing'
+import { cn } from '@/lib/utils'
+
+import styles from './HomepageShell.module.css'
+
+const sceneToneClasses: Record<HomepageSceneTone, string> = {
+  dawn: styles.sceneDawn,
+  forest: styles.sceneForest,
+  ink: styles.sceneInk,
+}
+
+interface HomepageSceneCardProps {
+  sceneId: string
+  modelId: AI_MODELS
+  tone: HomepageSceneTone
+  className?: string
+}
+
+export function HomepageSceneCard({
+  sceneId,
+  modelId,
+  tone,
+  className,
+}: HomepageSceneCardProps) {
+  const locale = useLocale()
+  const isDenseLocale = isCjkLocale(locale)
+  const t = useTranslations('Homepage')
+  const tModels = useTranslations('Models')
+
+  return (
+    <article
+      className={cn(styles.sceneCard, sceneToneClasses[tone], className)}
+    >
+      <span className={cn(styles.sceneTag, isDenseLocale && styles.denseCopy)}>
+        {tModels(`${getModelMessageKey(modelId)}.label`)}
+      </span>
+      <p className={styles.scenePrompt}>
+        {t(`scenes.items.${sceneId}.prompt`)}
+      </p>
+      <div className={styles.sceneMeta}>
+        <span>{t(`scenes.items.${sceneId}.note`)}</span>
+        <span>{t('stage.savedLabel')}</span>
+      </div>
+    </article>
+  )
+}

--- a/src/components/business/HomepageShell.tsx
+++ b/src/components/business/HomepageShell.tsx
@@ -1,82 +1,23 @@
-import type { LucideIcon } from 'lucide-react'
-import { Archive, ArrowRight, ShieldCheck, Sparkles } from 'lucide-react'
+import { ArrowRight } from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl'
 
-import { API_USAGE } from '@/constants/config'
-import type { AI_MODELS } from '@/constants/models'
 import {
-  HOMEPAGE_FEATURES,
   HOMEPAGE_NAVIGATION,
   HOMEPAGE_ROUTES,
   HOMEPAGE_SCENES,
-  HOMEPAGE_WORKFLOW,
-  type HomepageFeatureIcon,
-  type HomepageSceneTone,
 } from '@/constants/homepage'
-import { getModelMessageKey, MODEL_OPTIONS } from '@/constants/models'
-import { getProviderLabel } from '@/constants/providers'
 import { LocaleSwitcher } from '@/components/layout/LocaleSwitcher'
 import { Button } from '@/components/ui/button'
 import { Link } from '@/i18n/navigation'
 import { isCjkLocale } from '@/i18n/routing'
 import { cn } from '@/lib/utils'
 
+import { HomepageFeatures } from './HomepageFeatures'
+import { HomepageHero } from './HomepageHero'
+import { HomepageModels } from './HomepageModels'
+import { HomepageSceneCard } from './HomepageSceneCard'
+import { HomepageWorkflow } from './HomepageWorkflow'
 import styles from './HomepageShell.module.css'
-
-const featureIcons: Record<HomepageFeatureIcon, LucideIcon> = {
-  sparkles: Sparkles,
-  archive: Archive,
-  shield: ShieldCheck,
-}
-
-const sceneToneClasses: Record<HomepageSceneTone, string> = {
-  dawn: styles.sceneDawn,
-  forest: styles.sceneForest,
-  ink: styles.sceneInk,
-}
-
-const providerCount = new Set(MODEL_OPTIONS.map((model) => model.adapterType))
-  .size
-
-const HERO_SCENE_COUNT = 2
-
-interface SceneCardProps {
-  sceneId: string
-  modelId: AI_MODELS
-  tone: HomepageSceneTone
-  isDenseLocale: boolean
-  className?: string
-}
-
-function SceneCard({
-  sceneId,
-  modelId,
-  tone,
-  isDenseLocale,
-  className,
-}: SceneCardProps) {
-  const t = useTranslations('Homepage')
-  const tModels = useTranslations('Models')
-
-  return (
-    <article
-      className={cn(styles.sceneCard, sceneToneClasses[tone], className)}
-    >
-      <span
-        className={cn(styles.sceneTag, isDenseLocale && styles.denseCopy)}
-      >
-        {tModels(`${getModelMessageKey(modelId)}.label`)}
-      </span>
-      <p className={styles.scenePrompt}>
-        {t(`scenes.items.${sceneId}.prompt`)}
-      </p>
-      <div className={styles.sceneMeta}>
-        <span>{t(`scenes.items.${sceneId}.note`)}</span>
-        <span>{t('stage.savedLabel')}</span>
-      </div>
-    </article>
-  )
-}
 
 interface HomepageShellProps {
   eyebrow: string
@@ -105,63 +46,13 @@ export function HomepageShell({
   const isDenseLocale = isCjkLocale(locale)
   const t = useTranslations('Homepage')
   const tCommon = useTranslations('Common')
-  const tModels = useTranslations('Models')
-
-  const signalItems = (
-    <>
-      <div className={styles.signalItem}>
-        <span
-          className={cn(
-            styles.signalLabel,
-            isDenseLocale && styles.denseCopy,
-          )}
-        >
-          {t('signals.modelCoverageLabel')}
-        </span>
-        <span className={styles.signalValue}>
-          {t('signals.modelCoverageValue', {
-            modelCount: MODEL_OPTIONS.length,
-            providerCount,
-          })}
-        </span>
-      </div>
-      <div className={styles.signalItem}>
-        <span
-          className={cn(
-            styles.signalLabel,
-            isDenseLocale && styles.denseCopy,
-          )}
-        >
-          {t('signals.creditLabel')}
-        </span>
-        <span className={styles.signalValue}>
-          {t('signals.creditValue', {
-            creditCount: tCommon('creditCount', {
-              count: API_USAGE.DEFAULT_REQUESTS_PER_GENERATION,
-            }),
-          })}
-        </span>
-      </div>
-      <div className={styles.signalItem}>
-        <span
-          className={cn(
-            styles.signalLabel,
-            isDenseLocale && styles.denseCopy,
-          )}
-        >
-          {t('signals.archiveLabel')}
-        </span>
-        <span className={styles.signalValue}>
-          {t('signals.archiveValue')}
-        </span>
-      </div>
-    </>
-  )
 
   return (
     <div className={styles.page}>
       <header className={styles.header}>
-        <div className={`mx-auto max-w-content px-4 sm:px-6 lg:px-8 ${styles.headerInner}`}>
+        <div
+          className={`mx-auto max-w-content px-4 sm:px-6 lg:px-8 ${styles.headerInner}`}
+        >
           <Link href={HOMEPAGE_ROUTES.home} className={styles.brandBlock}>
             <span
               className={cn(
@@ -202,230 +93,62 @@ export function HomepageShell({
         className={`mx-auto max-w-content px-4 sm:px-6 lg:px-8 ${styles.shell}`}
       >
         <main className={styles.main}>
-          <section className={styles.hero}>
-            <div className={styles.heroGrid}>
-              <div className={styles.heroCopy}>
-                <p
-                  className={cn(
-                    styles.eyebrow,
-                    isDenseLocale && styles.denseCopy,
-                  )}
-                >
-                  {eyebrow}
-                </p>
-                <h1 className={styles.title}>{title}</h1>
-                <p className={styles.description}>{description}</p>
+          <HomepageHero
+            eyebrow={eyebrow}
+            title={title}
+            description={description}
+            primaryActionHref={primaryActionHref}
+            primaryActionLabel={primaryActionLabel}
+            secondaryActionHref={secondaryActionHref}
+            secondaryActionLabel={secondaryActionLabel}
+          />
 
-                <div className={styles.actions}>
-                  <Button asChild size="lg" className={styles.primaryButton}>
-                    <Link href={primaryActionHref}>
-                      {primaryActionLabel}
-                      <ArrowRight className="size-4" />
-                    </Link>
-                  </Button>
-
-                  <Button
-                    asChild
-                    variant="outline"
-                    size="lg"
-                    className={styles.secondaryButton}
-                  >
-                    <Link href={secondaryActionHref}>{secondaryActionLabel}</Link>
-                  </Button>
-                </div>
-              </div>
-
-              <div className={styles.heroVisual}>
-                <div className={styles.heroVisualInner}>
-                  {HOMEPAGE_SCENES.slice(0, HERO_SCENE_COUNT).map((scene) => (
-                    <SceneCard
-                      key={scene.id}
-                      sceneId={scene.id}
-                      modelId={scene.modelId}
-                      tone={scene.tone}
-                      isDenseLocale={isDenseLocale}
-                      className={styles.heroVisualCard}
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
-
-            <div className={styles.heroMetrics}>
-              {signalItems}
-            </div>
-          </section>
-
+          {/* Gallery Preview */}
           <section id="gallery" className={styles.galleryPreview}>
-              <div className={styles.galleryPreviewHead}>
-                <p
-                  className={cn(
-                    styles.sectionLabel,
-                    isDenseLocale && styles.denseCopy,
-                  )}
-                >
-                  {t('stage.label')}
-                </p>
-                <h2 className={styles.galleryPreviewTitle}>
-                  {t('stage.title')}
-                </h2>
-                <p className={styles.galleryPreviewDesc}>
-                  {t('stage.value')}
-                </p>
-              </div>
-
-              <div className={styles.sceneGrid}>
-                {HOMEPAGE_SCENES.map((scene) => (
-                  <SceneCard
-                    key={scene.id}
-                    sceneId={scene.id}
-                    modelId={scene.modelId}
-                    tone={scene.tone}
-                    isDenseLocale={isDenseLocale}
-                  />
-                ))}
-              </div>
-
-              <div className={styles.galleryPreviewActions}>
-                <Button asChild variant="outline" size="lg" className={styles.secondaryButton}>
-                  <Link href={HOMEPAGE_ROUTES.signUp}>
-                    {t('stage.cta')}
-                    <ArrowRight className="size-4" />
-                  </Link>
-                </Button>
-              </div>
-          </section>
-
-          <section className={styles.section}>
-            <div className={styles.sectionIntro}>
+            <div className={styles.galleryPreviewHead}>
               <p
                 className={cn(
                   styles.sectionLabel,
                   isDenseLocale && styles.denseCopy,
                 )}
               >
-                {t('features.eyebrow')}
+                {t('stage.label')}
               </p>
-              <h2 className={styles.sectionTitle}>{t('features.title')}</h2>
-              <p className={styles.sectionDescription}>
-                {t('features.description')}
-              </p>
+              <h2 className={styles.galleryPreviewTitle}>{t('stage.title')}</h2>
+              <p className={styles.galleryPreviewDesc}>{t('stage.value')}</p>
             </div>
 
-            <div className={styles.featureGrid}>
-              {HOMEPAGE_FEATURES.map((feature) => {
-                const FeatureIcon = featureIcons[feature.icon]
-
-                return (
-                  <article key={feature.id} className={styles.featureItem}>
-                    <div className={styles.featureHeader}>
-                      <span className={styles.featureIcon}>
-                        <FeatureIcon className="size-5" />
-                      </span>
-                      <h3 className={styles.featureTitle}>
-                        {t(`features.items.${feature.id}.title`)}
-                      </h3>
-                    </div>
-                    <p className={styles.featureDescription}>
-                      {t(`features.items.${feature.id}.description`)}
-                    </p>
-                  </article>
-                )
-              })}
-            </div>
-          </section>
-
-          <section id="workflow" className={styles.section}>
-            <div className={styles.sectionIntro}>
-              <p
-                className={cn(
-                  styles.sectionLabel,
-                  isDenseLocale && styles.denseCopy,
-                )}
-              >
-                {t('workflow.eyebrow')}
-              </p>
-              <h2 className={styles.sectionTitle}>{t('workflow.title')}</h2>
-              <p className={styles.sectionDescription}>
-                {t('workflow.description')}
-              </p>
-            </div>
-
-            <div className={styles.workflowGrid}>
-              {HOMEPAGE_WORKFLOW.map((item) => (
-                <article key={item.step} className={styles.workflowItem}>
-                  <span
-                    className={cn(
-                      styles.workflowStep,
-                      isDenseLocale && styles.denseCopy,
-                    )}
-                  >
-                    {item.step}
-                  </span>
-                  <h3 className={styles.workflowTitle}>
-                    {t(`workflow.items.${item.id}.title`)}
-                  </h3>
-                  <p className={styles.workflowDescription}>
-                    {t(`workflow.items.${item.id}.description`)}
-                  </p>
-                </article>
+            <div className={styles.sceneGrid}>
+              {HOMEPAGE_SCENES.map((scene) => (
+                <HomepageSceneCard
+                  key={scene.id}
+                  sceneId={scene.id}
+                  modelId={scene.modelId}
+                  tone={scene.tone}
+                />
               ))}
             </div>
-          </section>
 
-          <section id="models" className={styles.section}>
-            <div className={styles.sectionIntro}>
-              <p
-                className={cn(
-                  styles.sectionLabel,
-                  isDenseLocale && styles.denseCopy,
-                )}
+            <div className={styles.galleryPreviewActions}>
+              <Button
+                asChild
+                variant="outline"
+                size="lg"
+                className={styles.secondaryButton}
               >
-                {t('models.eyebrow')}
-              </p>
-              <h2 className={styles.sectionTitle}>{t('models.title')}</h2>
-              <p className={styles.sectionDescription}>
-                {t('models.description')}
-              </p>
-            </div>
-
-            <div className={styles.modelRail}>
-              {MODEL_OPTIONS.map((model) => (
-                <article key={model.id} className={styles.modelCard}>
-                  <div>
-                    <div className={styles.modelMeta}>
-                      <span
-                        className={cn(
-                          styles.providerTag,
-                          isDenseLocale && styles.denseCopy,
-                        )}
-                      >
-                        {getProviderLabel(model.providerConfig)}
-                      </span>
-                      <span
-                        className={cn(
-                          styles.costTag,
-                          isDenseLocale && styles.denseCopy,
-                        )}
-                      >
-                        {tCommon('creditCount', {
-                          count: API_USAGE.DEFAULT_REQUESTS_PER_GENERATION,
-                        })}
-                      </span>
-                    </div>
-                    <h3 className={styles.modelTitle}>
-                      {tModels(`${getModelMessageKey(model.id)}.label`)}
-                    </h3>
-                  </div>
-
-                  <p className={styles.modelDescription}>
-                    {tModels(`${getModelMessageKey(model.id)}.description`)}
-                  </p>
-                </article>
-              ))}
+                <Link href={HOMEPAGE_ROUTES.signUp}>
+                  {t('stage.cta')}
+                  <ArrowRight className="size-4" />
+                </Link>
+              </Button>
             </div>
           </section>
 
+          <HomepageFeatures />
+          <HomepageWorkflow />
+          <HomepageModels />
+
+          {/* Footer CTA */}
           <section className={styles.footerBand}>
             <p
               className={cn(

--- a/src/components/business/HomepageWorkflow.tsx
+++ b/src/components/business/HomepageWorkflow.tsx
@@ -1,0 +1,48 @@
+import { useLocale, useTranslations } from 'next-intl'
+
+import { HOMEPAGE_WORKFLOW } from '@/constants/homepage'
+import { isCjkLocale } from '@/i18n/routing'
+import { cn } from '@/lib/utils'
+
+import styles from './HomepageShell.module.css'
+
+export function HomepageWorkflow() {
+  const locale = useLocale()
+  const isDenseLocale = isCjkLocale(locale)
+  const t = useTranslations('Homepage')
+
+  return (
+    <section id="workflow" className={styles.section}>
+      <div className={styles.sectionIntro}>
+        <p
+          className={cn(styles.sectionLabel, isDenseLocale && styles.denseCopy)}
+        >
+          {t('workflow.eyebrow')}
+        </p>
+        <h2 className={styles.sectionTitle}>{t('workflow.title')}</h2>
+        <p className={styles.sectionDescription}>{t('workflow.description')}</p>
+      </div>
+
+      <div className={styles.workflowGrid}>
+        {HOMEPAGE_WORKFLOW.map((item) => (
+          <article key={item.step} className={styles.workflowItem}>
+            <span
+              className={cn(
+                styles.workflowStep,
+                isDenseLocale && styles.denseCopy,
+              )}
+            >
+              {item.step}
+            </span>
+            <h3 className={styles.workflowTitle}>
+              {t(`workflow.items.${item.id}.title`)}
+            </h3>
+            <p className={styles.workflowDescription}>
+              {t(`workflow.items.${item.id}.description`)}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/business/ImageCard.tsx
+++ b/src/components/business/ImageCard.tsx
@@ -13,14 +13,14 @@ import {
 } from 'lucide-react'
 import { useFormatter, useLocale, useTranslations } from 'next-intl'
 
-import { getModelMessageKey, isBuiltInModel } from '@/constants/models'
-import { useRouter } from '@/i18n/navigation'
 import { isCjkLocale } from '@/i18n/routing'
-import { toggleGenerationVisibility } from '@/lib/api-client'
 
 import type { GenerationRecord } from '@/types'
 import { ImageDetailModal } from '@/components/business/ImageDetailModal'
-import { cn } from '@/lib/utils'
+import { MetadataList } from '@/components/ui/metadata-list'
+import { useGenerationVisibility } from '@/hooks/use-generation-visibility'
+import { getTranslatedModelLabel } from '@/lib/model-options'
+import { cn, getLabelClassName } from '@/lib/utils'
 
 interface ImageCardProps {
   generation: GenerationRecord
@@ -35,13 +35,13 @@ export function ImageCard({
   showDelete = false,
   onDelete,
 }: ImageCardProps) {
-  const [isPublic, setIsPublic] = useState(generation.isPublic)
-  const [isPromptPublic, setIsPromptPublic] = useState(
-    generation.isPromptPublic,
-  )
-  const [togglingField, setTogglingField] = useState<string | null>(null)
+  const { isPublic, isPromptPublic, togglingField, handleToggle } =
+    useGenerationVisibility({
+      generationId: generation.id,
+      initialIsPublic: generation.isPublic,
+      initialIsPromptPublic: generation.isPromptPublic,
+    })
   const [detailOpen, setDetailOpen] = useState(false)
-  const router = useRouter()
   const format = useFormatter()
   const locale = useLocale()
   const isDenseLocale = isCjkLocale(locale)
@@ -49,33 +49,13 @@ export function ImageCard({
   const tCommon = useTranslations('Common')
   const tModels = useTranslations('Models')
 
-  const handleToggle = async (field: 'isPublic' | 'isPromptPublic') => {
-    if (togglingField) return
-    setTogglingField(field)
-    const setter = field === 'isPublic' ? setIsPublic : setIsPromptPublic
-    const prev = field === 'isPublic' ? isPublic : isPromptPublic
-    setter(!prev)
-    const result = await toggleGenerationVisibility(generation.id, field)
-    if (!result.success) {
-      setter(prev)
-    } else {
-      if (result.data) {
-        setIsPublic(result.data.isPublic)
-        setIsPromptPublic(result.data.isPromptPublic)
-      }
-      router.refresh()
-    }
-    setTogglingField(null)
-  }
-
   const createdAt = new Date(generation.createdAt)
-  const modelLabel = isBuiltInModel(generation.model)
-    ? tModels(`${getModelMessageKey(generation.model)}.label`)
-    : generation.model
+  const modelLabel = getTranslatedModelLabel(tModels, generation.model)
   const aspectRatio = `${Math.max(generation.width, 1)} / ${Math.max(
     generation.height,
     1,
   )}`
+
   const metadata = [
     {
       label: t('modelLabel'),
@@ -95,12 +75,7 @@ export function ImageCard({
     },
   ]
 
-  const labelClass = cn(
-    'text-nav font-semibold text-muted-foreground',
-    isDenseLocale
-      ? 'tracking-normal normal-case'
-      : 'uppercase tracking-nav-dense',
-  )
+  const labelClass = getLabelClassName(isDenseLocale)
 
   const detailGeneration = {
     ...generation,
@@ -132,7 +107,6 @@ export function ImageCard({
                 style={{ aspectRatio }}
               />
             ) : (
-              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={generation.url}
                 alt={generation.prompt}
@@ -201,83 +175,68 @@ export function ImageCard({
             </p>
           )}
 
-          <dl className="grid gap-2 border-t border-border/70 pt-3">
-            {metadata.map((item) => (
-              <div
-                key={item.key}
-                className="flex items-start justify-between gap-3"
-              >
-                <dt className={labelClass}>{item.label}</dt>
-                <dd className="flex items-center gap-1.5 text-right text-sm text-foreground">
-                  {item.icon}
-                  <span>{item.value}</span>
+          <MetadataList items={metadata} labelClassName={labelClass} />
+
+          {showVisibility ? (
+            <dl className="grid gap-2">
+              <div className="flex items-start justify-between gap-3 pt-0.5">
+                <dt className={labelClass}>{t('imageVisibilityLabel')}</dt>
+                <dd className="flex items-center gap-3">
+                  <span className="flex items-center gap-1.5 text-sm text-foreground">
+                    {isPublic ? (
+                      <Globe2 className="size-3 text-chart-2" />
+                    ) : (
+                      <LockKeyhole className="size-3 text-muted-foreground" />
+                    )}
+                    {isPublic ? t('publicLabel') : t('privateLabel')}
+                  </span>
+                  <button
+                    type="button"
+                    disabled={togglingField !== null}
+                    onClick={() => void handleToggle('isPublic')}
+                    className={cn(
+                      'text-nav font-semibold text-primary underline-offset-2 transition-opacity hover:underline disabled:pointer-events-none',
+                      isDenseLocale
+                        ? 'tracking-normal normal-case'
+                        : 'uppercase tracking-nav-dense',
+                      togglingField !== null && 'opacity-50',
+                    )}
+                  >
+                    {isPublic ? t('makePrivateAction') : t('makePublicAction')}
+                  </button>
                 </dd>
               </div>
-            ))}
-
-            {showVisibility ? (
-              <>
-                <div className="flex items-start justify-between gap-3 pt-0.5">
-                  <dt className={labelClass}>{t('imageVisibilityLabel')}</dt>
-                  <dd className="flex items-center gap-3">
-                    <span className="flex items-center gap-1.5 text-sm text-foreground">
-                      {isPublic ? (
-                        <Globe2 className="size-3 text-chart-2" />
-                      ) : (
-                        <LockKeyhole className="size-3 text-muted-foreground" />
-                      )}
-                      {isPublic ? t('publicLabel') : t('privateLabel')}
-                    </span>
-                    <button
-                      type="button"
-                      disabled={togglingField !== null}
-                      onClick={() => void handleToggle('isPublic')}
-                      className={cn(
-                        'text-nav font-semibold text-primary underline-offset-2 transition-opacity hover:underline disabled:pointer-events-none',
-                        isDenseLocale
-                          ? 'tracking-normal normal-case'
-                          : 'uppercase tracking-nav-dense',
-                        togglingField !== null && 'opacity-50',
-                      )}
-                    >
-                      {isPublic
-                        ? t('makePrivateAction')
-                        : t('makePublicAction')}
-                    </button>
-                  </dd>
-                </div>
-                <div className="flex items-start justify-between gap-3">
-                  <dt className={labelClass}>{t('promptVisibilityLabel')}</dt>
-                  <dd className="flex items-center gap-3">
-                    <span className="flex items-center gap-1.5 text-sm text-foreground">
-                      {isPromptPublic ? (
-                        <Globe2 className="size-3 text-chart-2" />
-                      ) : (
-                        <LockKeyhole className="size-3 text-muted-foreground" />
-                      )}
-                      {isPromptPublic ? t('publicLabel') : t('privateLabel')}
-                    </span>
-                    <button
-                      type="button"
-                      disabled={togglingField !== null}
-                      onClick={() => void handleToggle('isPromptPublic')}
-                      className={cn(
-                        'text-nav font-semibold text-primary underline-offset-2 transition-opacity hover:underline disabled:pointer-events-none',
-                        isDenseLocale
-                          ? 'tracking-normal normal-case'
-                          : 'uppercase tracking-nav-dense',
-                        togglingField !== null && 'opacity-50',
-                      )}
-                    >
-                      {isPromptPublic
-                        ? t('makePrivateAction')
-                        : t('makePublicAction')}
-                    </button>
-                  </dd>
-                </div>
-              </>
-            ) : null}
-          </dl>
+              <div className="flex items-start justify-between gap-3">
+                <dt className={labelClass}>{t('promptVisibilityLabel')}</dt>
+                <dd className="flex items-center gap-3">
+                  <span className="flex items-center gap-1.5 text-sm text-foreground">
+                    {isPromptPublic ? (
+                      <Globe2 className="size-3 text-chart-2" />
+                    ) : (
+                      <LockKeyhole className="size-3 text-muted-foreground" />
+                    )}
+                    {isPromptPublic ? t('publicLabel') : t('privateLabel')}
+                  </span>
+                  <button
+                    type="button"
+                    disabled={togglingField !== null}
+                    onClick={() => void handleToggle('isPromptPublic')}
+                    className={cn(
+                      'text-nav font-semibold text-primary underline-offset-2 transition-opacity hover:underline disabled:pointer-events-none',
+                      isDenseLocale
+                        ? 'tracking-normal normal-case'
+                        : 'uppercase tracking-nav-dense',
+                      togglingField !== null && 'opacity-50',
+                    )}
+                  >
+                    {isPromptPublic
+                      ? t('makePrivateAction')
+                      : t('makePublicAction')}
+                  </button>
+                </dd>
+              </div>
+            </dl>
+          ) : null}
         </div>
       </article>
 

--- a/src/components/business/ImageDetailModal.tsx
+++ b/src/components/business/ImageDetailModal.tsx
@@ -14,30 +14,21 @@ import {
 } from 'lucide-react'
 import { useFormatter, useLocale, useTranslations } from 'next-intl'
 
-import { getModelMessageKey, isBuiltInModel } from '@/constants/models'
 import { isCjkLocale } from '@/i18n/routing'
 
 import type { GenerationRecord } from '@/types'
 import VideoPlayer from '@/components/business/VideoPlayer'
 import { Button } from '@/components/ui/button'
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog'
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { cn } from '@/lib/utils'
+import { MetadataList } from '@/components/ui/metadata-list'
+import { getTranslatedModelLabel } from '@/lib/model-options'
+import { cn, getLabelClassName } from '@/lib/utils'
 
 interface ImageDetailModalProps {
   generation: GenerationRecord
@@ -66,9 +57,7 @@ export function ImageDetailModal({
   const tModels = useTranslations('Models')
 
   const createdAt = new Date(generation.createdAt)
-  const modelLabel = isBuiltInModel(generation.model)
-    ? tModels(`${getModelMessageKey(generation.model)}.label`)
-    : generation.model
+  const modelLabel = getTranslatedModelLabel(tModels, generation.model)
 
   const aspectRatio = `${Math.max(generation.width, 1)} / ${Math.max(
     generation.height,
@@ -97,12 +86,7 @@ export function ImageDetailModal({
     }
   }
 
-  const labelClass = cn(
-    'text-nav font-semibold text-muted-foreground',
-    isDenseLocale
-      ? 'tracking-normal normal-case'
-      : 'uppercase tracking-nav-dense',
-  )
+  const labelClass = getLabelClassName(isDenseLocale)
 
   const metadata = [
     { label: tCard('modelLabel'), value: modelLabel, key: 'model' },
@@ -116,6 +100,11 @@ export function ImageDetailModal({
       value: tCommon('creditCount', { count: generation.requestCount }),
       key: 'requests',
       icon: <Coins className="size-3 text-primary" />,
+    },
+    {
+      label: t('dimensionsLabel'),
+      value: `${generation.width} \u00d7 ${generation.height}`,
+      key: 'dimensions',
     },
   ]
 
@@ -240,26 +229,7 @@ export function ImageDetailModal({
             </div>
           ) : null}
 
-          <dl className="grid gap-2 border-t border-border/70 pt-4">
-            {metadata.map((item) => (
-              <div
-                key={item.key}
-                className="flex items-start justify-between gap-3"
-              >
-                <dt className={labelClass}>{item.label}</dt>
-                <dd className="flex items-center gap-1.5 text-right text-sm text-foreground">
-                  {item.icon}
-                  <span>{item.value}</span>
-                </dd>
-              </div>
-            ))}
-            <div className="flex items-start justify-between gap-3">
-              <dt className={labelClass}>{t('dimensionsLabel')}</dt>
-              <dd className="text-right text-sm text-foreground">
-                {generation.width} &times; {generation.height}
-              </dd>
-            </div>
-          </dl>
+          <MetadataList items={metadata} labelClassName={labelClass} />
 
           <div className="flex flex-wrap gap-2 border-t border-border/70 pt-4">
             <Button
@@ -286,8 +256,8 @@ export function ImageDetailModal({
             </Button>
 
             {showDelete && onDelete ? (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
+              <ConfirmDialog
+                trigger={
                   <Button
                     variant="outline"
                     size="sm"
@@ -296,32 +266,16 @@ export function ImageDetailModal({
                     <Trash2 className="size-3.5" />
                     {t('delete')}
                   </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent className="rounded-3xl">
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      {t('deleteConfirmTitle')}
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {t('deleteConfirmDescription')}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel className="rounded-full">
-                      {t('deleteCancel')}
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      className="rounded-full bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                      onClick={() => {
-                        onDelete(generation.id)
-                        onOpenChange(false)
-                      }}
-                    >
-                      {t('deleteConfirm')}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+                }
+                title={t('deleteConfirmTitle')}
+                description={t('deleteConfirmDescription')}
+                cancelLabel={t('deleteCancel')}
+                confirmLabel={t('deleteConfirm')}
+                onConfirm={() => {
+                  onDelete(generation.id)
+                  onOpenChange(false)
+                }}
+              />
             ) : null}
           </div>
         </div>

--- a/src/components/business/PromptEnhancer.tsx
+++ b/src/components/business/PromptEnhancer.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import type { PromptEnhanceStyle } from '@/constants/config'
+
+import { PromptEnhanceButton } from '@/components/business/PromptEnhanceButton'
+import { PromptComparisonPanel } from '@/components/business/PromptComparisonPanel'
+
+interface PromptEnhancerProps {
+  prompt: string
+  isEnhancing: boolean
+  disabled: boolean
+  enhanced: string | null
+  enhancedOriginal: string | null
+  enhancedStyle: PromptEnhanceStyle | null
+  onEnhance: (style: PromptEnhanceStyle) => void
+  onUseEnhanced: (text: string) => void
+  onDismiss: () => void
+}
+
+/**
+ * Unified prompt enhancement module combining the enhance button
+ * and comparison panel with consistent null handling.
+ * Used in GenerateForm and VideoGenerateForm.
+ */
+export function PromptEnhancer({
+  prompt,
+  isEnhancing,
+  disabled,
+  enhanced,
+  enhancedOriginal,
+  enhancedStyle,
+  onEnhance,
+  onUseEnhanced,
+  onDismiss,
+}: PromptEnhancerProps) {
+  return (
+    <>
+      <PromptEnhanceButton
+        prompt={prompt}
+        isEnhancing={isEnhancing}
+        disabled={disabled}
+        onEnhance={onEnhance}
+      />
+
+      {enhanced && enhancedOriginal && enhancedStyle && (
+        <div className="mt-3">
+          <PromptComparisonPanel
+            original={enhancedOriginal}
+            enhanced={enhanced}
+            style={enhancedStyle}
+            onUseEnhanced={onUseEnhanced}
+            onDismiss={onDismiss}
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/business/VideoGenerateForm.tsx
+++ b/src/components/business/VideoGenerateForm.tsx
@@ -1,22 +1,10 @@
 'use client'
 
-import { useCallback, useRef, useState } from 'react'
-import {
-  AlertCircle,
-  ChevronDown,
-  ChevronUp,
-  Film,
-  Loader2,
-  Upload,
-  X,
-} from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { Film, Loader2, X } from 'lucide-react'
 import { useLocale, useTranslations } from 'next-intl'
 
-import {
-  API_USAGE,
-  GENERATION_LIMITS,
-  VIDEO_GENERATION,
-} from '@/constants/config'
+import { GENERATION_LIMITS, VIDEO_GENERATION } from '@/constants/config'
 import { getAvailableVideoModels, getModelById } from '@/constants/models'
 import { isCjkLocale } from '@/i18n/routing'
 
@@ -24,15 +12,19 @@ import {
   ModelSelector,
   type StudioModelOption,
 } from '@/components/business/ModelSelector'
-import { PromptComparisonPanel } from '@/components/business/PromptComparisonPanel'
-import { PromptEnhanceButton } from '@/components/business/PromptEnhanceButton'
+import { PromptEnhancer } from '@/components/business/PromptEnhancer'
 import VideoPlayer from '@/components/business/VideoPlayer'
+import { CollapsiblePanel } from '@/components/ui/collapsible-panel'
+import { ErrorAlert } from '@/components/ui/error-alert'
+import { ImageDropZone } from '@/components/ui/image-drop-zone'
+import { OptionGroup } from '@/components/ui/option-group'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { useApiKeysContext } from '@/contexts/api-keys-context'
 import { useGenerateVideo } from '@/hooks/use-generate-video'
-import { usePromptEnhance } from '@/hooks/use-prompt-enhance'
+import { useGenerationForm } from '@/hooks/use-generation-form'
+import { buildSavedModelOptions, findSelectedModel } from '@/lib/model-options'
 import { cn } from '@/lib/utils'
 
 function formatDuration(seconds: number): string {
@@ -50,15 +42,6 @@ const VIDEO_SIZES: Record<string, { width: number; height: number }> = {
   '9:16': { width: 720, height: 1280 },
   '4:3': { width: 1024, height: 768 },
   '3:4': { width: 768, height: 1024 },
-}
-
-function loadImageAsBase64(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(reader.result as string)
-    reader.onerror = reject
-    reader.readAsDataURL(file)
-  })
 }
 
 /** Resize a base64 data-URL image to exact dimensions using Canvas */
@@ -87,7 +70,6 @@ export default function VideoGenerateForm() {
   const locale = useLocale()
   const cjk = isCjkLocale(locale)
   const t = useTranslations('VideoGenerate')
-  const tModels = useTranslations('Models')
 
   const { keys } = useApiKeysContext()
   const {
@@ -98,29 +80,38 @@ export default function VideoGenerateForm() {
     generatedGeneration,
     generate,
   } = useGenerateVideo()
+
   const {
+    prompt,
+    setPrompt,
+    aspectRatio,
+    setAspectRatio,
+    referenceImage,
+    isDragging,
+    fileInputRef,
+    handleDrop,
+    handleDragOver,
+    handleDragLeave,
+    openFilePicker,
+    handleInputChange,
+    clearImage,
     isEnhancing,
     enhanced,
-    original: enhancedOriginal,
-    style: enhancedStyle,
-    enhance: enhancePrompt,
+    enhancedOriginal,
+    enhancedStyle,
+    enhancePrompt,
     clearEnhancement,
-  } = usePromptEnhance()
+    applyEnhancedPrompt,
+  } = useGenerationForm({
+    defaultAspectRatio: VIDEO_GENERATION.DEFAULT_ASPECT_RATIO,
+  })
 
   const [selectedOptionId, setSelectedOptionId] = useState('')
-  const [prompt, setPrompt] = useState('')
   const [duration, setDuration] = useState<number>(
     VIDEO_GENERATION.DEFAULT_DURATION,
   )
-  const [aspectRatio, setAspectRatio] = useState<string>(
-    VIDEO_GENERATION.DEFAULT_ASPECT_RATIO,
-  )
-  const [referenceImage, setReferenceImage] = useState<string | undefined>()
   const [resolution, setResolution] = useState<string | undefined>()
-  const [showAdvanced, setShowAdvanced] = useState(false)
   const [negativePrompt, setNegativePrompt] = useState('')
-  const [isDragging, setIsDragging] = useState(false)
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const videoModels = getAvailableVideoModels()
 
@@ -133,53 +124,23 @@ export default function VideoGenerateForm() {
     isBuiltIn: true,
     sourceType: 'workspace',
   }))
-  const savedOptions: StudioModelOption[] = keys
-    .filter(
-      (key) => key.isActive && videoModels.some((m) => m.id === key.modelId),
-    )
-    .map((key) => ({
-      optionId: `key:${key.id}`,
-      modelId: key.modelId,
-      adapterType: key.adapterType,
-      providerConfig: key.providerConfig,
-      requestCount: API_USAGE.DEFAULT_REQUESTS_PER_GENERATION,
-      isBuiltIn: false,
-      sourceType: 'saved',
-      keyId: key.id,
-      keyLabel: key.label,
-      maskedKey: key.maskedKey,
-    }))
+  const savedOptions = buildSavedModelOptions(
+    keys.filter((key) => key.isActive),
+    (key) => videoModels.some((m) => m.id === key.modelId),
+  )
   const modelOptions = [...builtInOptions, ...savedOptions]
-  const selectedModel =
-    modelOptions.find((o) => o.optionId === selectedOptionId) ?? modelOptions[0]
+  const selectedModel = findSelectedModel(modelOptions, selectedOptionId)
 
   const selectedApiKeyId = selectedModel?.keyId
   const selectedModelConfig = selectedModel
     ? getModelById(selectedModel.modelId)
     : undefined
 
-  const handleFileChange = useCallback(async (file: File) => {
-    if (!file.type.startsWith('image/')) return
-    const base64 = await loadImageAsBase64(file)
-    setReferenceImage(base64)
-  }, [])
-
-  const handleDrop = useCallback(
-    async (e: React.DragEvent<HTMLDivElement>) => {
-      e.preventDefault()
-      setIsDragging(false)
-      const file = e.dataTransfer.files[0]
-      if (file) await handleFileChange(file)
-    },
-    [handleFileChange],
-  )
-
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
       e.preventDefault()
       if (!selectedModel || !prompt.trim()) return
 
-      // For OpenAI Sora: resize reference image to match video dimensions
       let processedImage = referenceImage
       if (referenceImage && selectedModel.adapterType === 'openai') {
         const dims = VIDEO_SIZES[aspectRatio] ?? VIDEO_SIZES['16:9']
@@ -267,23 +228,15 @@ export default function VideoGenerateForm() {
           >
             {t('durationLabel')}
           </label>
-          <div className="flex gap-2">
-            {VIDEO_GENERATION.DURATION_OPTIONS.map((d) => (
-              <button
-                key={d}
-                type="button"
-                onClick={() => setDuration(d)}
-                className={cn(
-                  'rounded-full px-4 py-2 text-sm font-medium transition-colors',
-                  duration === d
-                    ? 'bg-foreground text-background'
-                    : 'border border-border/75 bg-background/50 text-foreground hover:bg-muted/30',
-                )}
-              >
-                {d}s
-              </button>
-            ))}
-          </div>
+          <OptionGroup
+            options={VIDEO_GENERATION.DURATION_OPTIONS.map((d) => ({
+              value: String(d),
+              label: `${d}s`,
+            }))}
+            value={String(duration)}
+            onChange={(v) => setDuration(Number(v))}
+            variant="neutral"
+          />
         </div>
 
         <div className="min-w-0 rounded-3xl border border-border/75 bg-card/82 p-5">
@@ -295,23 +248,12 @@ export default function VideoGenerateForm() {
           >
             {t('aspectRatioLabel')}
           </label>
-          <div className="flex flex-wrap gap-2">
-            {(['16:9', '9:16', '1:1'] as const).map((ar) => (
-              <button
-                key={ar}
-                type="button"
-                onClick={() => setAspectRatio(ar)}
-                className={cn(
-                  'rounded-full px-4 py-2 text-sm font-medium transition-colors',
-                  aspectRatio === ar
-                    ? 'bg-foreground text-background'
-                    : 'border border-border/75 bg-background/50 text-foreground hover:bg-muted/30',
-                )}
-              >
-                {ar}
-              </button>
-            ))}
-          </div>
+          <OptionGroup
+            options={['16:9', '9:16', '1:1']}
+            value={aspectRatio}
+            onChange={setAspectRatio}
+            variant="neutral"
+          />
         </div>
 
         <div className="min-w-0 rounded-3xl border border-border/75 bg-card/82 p-5">
@@ -323,23 +265,13 @@ export default function VideoGenerateForm() {
           >
             {t('resolutionLabel')}
           </label>
-          <div className="flex flex-wrap gap-2">
-            {RESOLUTION_OPTIONS.map((r) => (
-              <button
-                key={r}
-                type="button"
-                onClick={() => setResolution(resolution === r ? undefined : r)}
-                className={cn(
-                  'rounded-full px-4 py-2 text-sm font-medium transition-colors',
-                  resolution === r
-                    ? 'bg-foreground text-background'
-                    : 'border border-border/75 bg-background/50 text-foreground hover:bg-muted/30',
-                )}
-              >
-                {r}
-              </button>
-            ))}
-          </div>
+          <OptionGroup
+            options={RESOLUTION_OPTIONS.map((r) => r)}
+            value={resolution ?? ''}
+            onChange={(v) => setResolution(v || undefined)}
+            allowDeselect
+            variant="neutral"
+          />
         </div>
       </div>
 
@@ -372,43 +304,22 @@ export default function VideoGenerateForm() {
             <button
               type="button"
               aria-label={t('referenceRemoveLabel')}
-              onClick={() => setReferenceImage(undefined)}
+              onClick={clearImage}
               className="absolute right-3 top-3 rounded-full border border-border/75 bg-background/92 p-1.5 text-muted-foreground transition-colors hover:text-destructive"
             >
               <X className="size-3.5" />
             </button>
           </div>
         ) : (
-          <div
-            role="button"
-            tabIndex={0}
-            onDragOver={(e) => {
-              e.preventDefault()
-              setIsDragging(true)
-            }}
-            onDragLeave={() => setIsDragging(false)}
+          <ImageDropZone
+            isDragging={isDragging}
             onDrop={handleDrop}
-            onClick={() => fileInputRef.current?.click()}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                fileInputRef.current?.click()
-              }
-            }}
-            className={cn(
-              'flex cursor-pointer flex-col items-center gap-2 rounded-2xl border-2 border-dashed px-6 py-8 text-center transition-colors',
-              isDragging
-                ? 'border-primary/60 bg-primary/5'
-                : 'border-border/80 bg-background/72 hover:border-primary/40 hover:bg-secondary/18',
-            )}
-          >
-            <Upload className="size-5 text-muted-foreground" />
-            <p className="text-sm font-medium text-foreground">
-              {t('referenceImageUpload')}
-            </p>
-            <p className="font-serif text-xs text-muted-foreground">
-              {t('referenceImageHint')}
-            </p>
-          </div>
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onClick={openFilePicker}
+            uploadLabel={t('referenceImageUpload')}
+            formatsLabel={t('referenceImageHint')}
+          />
         )}
         <input
           ref={fileInputRef}
@@ -416,10 +327,7 @@ export default function VideoGenerateForm() {
           accept="image/*"
           aria-label={t('referenceImageLabel')}
           className="hidden"
-          onChange={async (e) => {
-            const file = e.target.files?.[0]
-            if (file) await handleFileChange(file)
-          }}
+          onChange={handleInputChange}
         />
       </div>
 
@@ -435,13 +343,18 @@ export default function VideoGenerateForm() {
             {t('promptLabel')}
           </label>
           <div className="flex items-center gap-2">
-            <PromptEnhanceButton
+            <PromptEnhancer
               prompt={prompt}
               isEnhancing={isEnhancing}
               disabled={isGenerating}
+              enhanced={enhanced}
+              enhancedOriginal={enhancedOriginal}
+              enhancedStyle={enhancedStyle}
               onEnhance={(style) =>
                 enhancePrompt(prompt, style, selectedApiKeyId)
               }
+              onUseEnhanced={applyEnhancedPrompt}
+              onDismiss={clearEnhancement}
             />
             <span className="text-xs tabular-nums text-muted-foreground">
               {prompt.length}/{GENERATION_LIMITS.PROMPT_MAX_LENGTH}
@@ -456,60 +369,24 @@ export default function VideoGenerateForm() {
           rows={4}
           className="min-h-28 rounded-3xl border-border/75 bg-background/72"
         />
-
-        {enhanced && (
-          <div className="mt-3">
-            <PromptComparisonPanel
-              original={enhancedOriginal ?? ''}
-              enhanced={enhanced}
-              style={enhancedStyle ?? ''}
-              onUseEnhanced={(text) => {
-                setPrompt(text)
-                clearEnhancement()
-              }}
-              onDismiss={clearEnhancement}
-            />
-          </div>
-        )}
       </div>
 
       {/* Advanced Settings */}
-      <div className="rounded-3xl border border-border/75 bg-card/82 p-5 sm:p-6">
-        <button
-          type="button"
-          onClick={() => setShowAdvanced(!showAdvanced)}
-          className="flex w-full items-center justify-between"
-        >
-          <span
-            className={cn(
-              'text-xs font-semibold text-muted-foreground',
-              !cjk && 'uppercase tracking-nav',
-            )}
-          >
-            {t('advancedSettings')}
-          </span>
-          {showAdvanced ? (
-            <ChevronUp className="size-4 text-muted-foreground" />
-          ) : (
-            <ChevronDown className="size-4 text-muted-foreground" />
-          )}
-        </button>
-
-        {showAdvanced && (
-          <div className="mt-4 border-t border-border/70 pt-4">
-            <label className="mb-2 block text-xs text-muted-foreground">
-              {t('negativePromptLabel')}
-            </label>
-            <Textarea
-              value={negativePrompt}
-              onChange={(e) => setNegativePrompt(e.target.value)}
-              placeholder={t('negativePromptPlaceholder')}
-              rows={2}
-              className="min-h-16 rounded-2xl border-border/75 bg-background/72 text-sm"
-            />
-          </div>
-        )}
-      </div>
+      <CollapsiblePanel
+        title={t('advancedSettings')}
+        className="rounded-3xl border border-border/75 bg-card/82 p-5 sm:p-6"
+      >
+        <label className="mb-2 block text-xs text-muted-foreground">
+          {t('negativePromptLabel')}
+        </label>
+        <Textarea
+          value={negativePrompt}
+          onChange={(e) => setNegativePrompt(e.target.value)}
+          placeholder={t('negativePromptPlaceholder')}
+          rows={2}
+          className="min-h-16 rounded-2xl border-border/75 bg-background/72 text-sm"
+        />
+      </CollapsiblePanel>
 
       {/* Submit */}
       <div className="rounded-3xl border border-border/75 bg-primary/6 p-5 sm:p-6">
@@ -576,12 +453,7 @@ export default function VideoGenerateForm() {
       )}
 
       {/* Error */}
-      {error && (
-        <div className="flex items-start gap-3 rounded-3xl border border-destructive/35 bg-destructive/8 p-4">
-          <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
-          <p className="font-serif text-sm text-destructive">{error}</p>
-        </div>
-      )}
+      {error && <ErrorAlert message={error} />}
 
       {/* Result */}
       {generatedGeneration && (

--- a/src/components/ui/aspect-ratio-selector.tsx
+++ b/src/components/ui/aspect-ratio-selector.tsx
@@ -1,0 +1,36 @@
+import { OptionGroup } from '@/components/ui/option-group'
+
+interface OptionItem {
+  value: string
+  label: string
+}
+
+interface AspectRatioSelectorProps {
+  options: readonly OptionItem[] | readonly string[]
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+  variant?: 'primary' | 'neutral'
+}
+
+/**
+ * Aspect ratio pill selector. Thin wrapper around OptionGroup
+ * for semantic clarity in generation forms.
+ */
+export function AspectRatioSelector({
+  options,
+  value,
+  onChange,
+  disabled,
+  variant = 'primary',
+}: AspectRatioSelectorProps) {
+  return (
+    <OptionGroup
+      options={options}
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+      variant={variant}
+    />
+  )
+}

--- a/src/components/ui/collapsible-panel.tsx
+++ b/src/components/ui/collapsible-panel.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+
+interface CollapsiblePanelProps {
+  title: string
+  description?: string
+  badge?: React.ReactNode
+  defaultOpen?: boolean
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * Collapsible panel with toggle button, used across generation forms
+ * for reference image, advanced settings, reverse engineer, etc.
+ */
+export function CollapsiblePanel({
+  title,
+  description,
+  badge,
+  defaultOpen = false,
+  className,
+  children,
+}: CollapsiblePanelProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen)
+
+  return (
+    <div
+      className={
+        className ?? 'rounded-3xl border border-border/70 bg-background/46 p-4'
+      }
+    >
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="flex w-full items-center justify-between gap-4 text-left"
+      >
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-foreground">{title}</p>
+          {description && (
+            <p className="font-serif text-sm leading-6 text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {badge}
+          {isOpen ? (
+            <ChevronUp className="size-4 text-muted-foreground" />
+          ) : (
+            <ChevronDown className="size-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      {isOpen && (
+        <div className="mt-4 border-t border-border/70 pt-4">{children}</div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,60 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+
+interface ConfirmDialogProps {
+  trigger: React.ReactNode
+  title: string
+  description: string
+  cancelLabel: string
+  confirmLabel: string
+  onConfirm: () => void
+  variant?: 'destructive' | 'default'
+}
+
+/**
+ * Standardized confirmation dialog wrapping AlertDialog.
+ * Used for delete confirmations and other destructive actions.
+ */
+export function ConfirmDialog({
+  trigger,
+  title,
+  description,
+  cancelLabel,
+  confirmLabel,
+  onConfirm,
+  variant = 'destructive',
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{trigger}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction
+            className={
+              variant === 'destructive'
+                ? 'rounded-full bg-destructive text-destructive-foreground hover:bg-destructive/90'
+                : 'rounded-full'
+            }
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/components/ui/error-alert.tsx
+++ b/src/components/ui/error-alert.tsx
@@ -1,0 +1,24 @@
+import { AlertCircle } from 'lucide-react'
+
+interface ErrorAlertProps {
+  title?: string
+  message: string
+  children?: React.ReactNode
+}
+
+/**
+ * Standardized error alert with destructive styling.
+ * Used in generation forms to display API errors.
+ */
+export function ErrorAlert({ title, message, children }: ErrorAlertProps) {
+  return (
+    <div className="flex items-start gap-3 rounded-2xl border border-destructive/25 bg-destructive/5 p-4 text-sm text-destructive">
+      <AlertCircle className="mt-0.5 size-4 shrink-0" />
+      <div className="space-y-1">
+        {title && <p className="font-medium">{title}</p>}
+        <p>{message}</p>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/image-drop-zone.tsx
+++ b/src/components/ui/image-drop-zone.tsx
@@ -1,0 +1,53 @@
+import { Upload } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+interface ImageDropZoneProps {
+  isDragging: boolean
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void
+  onDragOver: (e: React.DragEvent) => void
+  onDragLeave: () => void
+  onClick: () => void
+  uploadLabel: string
+  formatsLabel: string
+}
+
+/**
+ * Drag-and-drop zone for image upload with click-to-browse.
+ * Used in GenerateForm, VideoGenerateForm, and ArenaForm.
+ */
+export function ImageDropZone({
+  isDragging,
+  onDrop,
+  onDragOver,
+  onDragLeave,
+  onClick,
+  uploadLabel,
+  formatsLabel,
+}: ImageDropZoneProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          onClick()
+        }
+      }}
+      className={cn(
+        'flex cursor-pointer flex-col items-center gap-2 rounded-2xl border-2 border-dashed px-6 py-10 text-center transition-colors',
+        isDragging
+          ? 'border-primary/50 bg-primary/5'
+          : 'border-border/60 bg-background/60 hover:border-primary/30 hover:bg-primary/3',
+      )}
+    >
+      <Upload className="size-5 text-muted-foreground" />
+      <p className="text-sm font-medium text-foreground">{uploadLabel}</p>
+      <p className="font-serif text-xs text-muted-foreground">{formatsLabel}</p>
+    </div>
+  )
+}

--- a/src/components/ui/metadata-list.tsx
+++ b/src/components/ui/metadata-list.tsx
@@ -1,0 +1,30 @@
+interface MetadataItem {
+  label: string
+  value: string
+  key: string
+  icon?: React.ReactNode
+}
+
+interface MetadataListProps {
+  items: MetadataItem[]
+  labelClassName: string
+}
+
+/**
+ * Key-value metadata display used in gallery cards and detail modals.
+ */
+export function MetadataList({ items, labelClassName }: MetadataListProps) {
+  return (
+    <dl className="grid gap-2 border-t border-border/70 pt-3">
+      {items.map((item) => (
+        <div key={item.key} className="flex items-start justify-between gap-3">
+          <dt className={labelClassName}>{item.label}</dt>
+          <dd className="flex items-center gap-1.5 text-right text-sm text-foreground">
+            {item.icon}
+            <span>{item.value}</span>
+          </dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/src/components/ui/option-group.tsx
+++ b/src/components/ui/option-group.tsx
@@ -1,0 +1,66 @@
+import { cn } from '@/lib/utils'
+
+interface OptionGroupItem {
+  value: string
+  label: string
+}
+
+interface OptionGroupProps {
+  options: readonly OptionGroupItem[] | readonly string[]
+  value: string | undefined
+  onChange: (value: string) => void
+  disabled?: boolean
+  allowDeselect?: boolean
+  /** Visual style variant */
+  variant?: 'primary' | 'neutral'
+}
+
+/**
+ * Generic pill-button group for selecting from a list of options.
+ * Used for aspect ratio, duration, resolution, etc.
+ */
+export function OptionGroup({
+  options,
+  value,
+  onChange,
+  disabled = false,
+  allowDeselect = false,
+  variant = 'primary',
+}: OptionGroupProps) {
+  const normalizedOptions: OptionGroupItem[] = options.map((opt) =>
+    typeof opt === 'string' ? { value: opt, label: opt } : opt,
+  )
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {normalizedOptions.map((opt) => {
+        const isSelected = value === opt.value
+
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            disabled={disabled}
+            onClick={() => {
+              if (allowDeselect && isSelected) {
+                onChange('')
+              } else {
+                onChange(opt.value)
+              }
+            }}
+            className={cn(
+              'rounded-full px-4 py-2 text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50',
+              isSelected
+                ? variant === 'primary'
+                  ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/20'
+                  : 'bg-foreground text-background'
+                : 'border border-border/60 bg-background/50 text-foreground hover:bg-primary/5 hover:border-primary/20',
+            )}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/hooks/use-async-action.ts
+++ b/src/hooks/use-async-action.ts
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+
+interface UseAsyncActionOptions<T> {
+  onSuccess?: (data: T) => void
+  onError?: (message: string) => void
+}
+
+interface UseAsyncActionReturn<TParams extends unknown[], TResult> {
+  execute: (...args: TParams) => Promise<TResult | undefined>
+  isLoading: boolean
+  error: string | null
+  data: TResult | null
+  reset: () => void
+}
+
+/**
+ * Generic hook for managing async action state (loading, error, data).
+ * Wraps any async function with standardized state management.
+ */
+export function useAsyncAction<TParams extends unknown[], TResult>(
+  action: (...args: TParams) => Promise<TResult>,
+  options?: UseAsyncActionOptions<TResult>,
+): UseAsyncActionReturn<TParams, TResult> {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [data, setData] = useState<TResult | null>(null)
+
+  const execute = useCallback(
+    async (...args: TParams): Promise<TResult | undefined> => {
+      setIsLoading(true)
+      setError(null)
+      setData(null)
+
+      try {
+        const result = await action(...args)
+        setData(result)
+        options?.onSuccess?.(result)
+        return result
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'An unexpected error occurred'
+        setError(message)
+        options?.onError?.(message)
+        return undefined
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [action],
+  )
+
+  const reset = useCallback(() => {
+    setError(null)
+    setData(null)
+  }, [])
+
+  return { execute, isLoading, error, data, reset }
+}

--- a/src/hooks/use-generation-form.ts
+++ b/src/hooks/use-generation-form.ts
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+
+import { DEFAULT_ASPECT_RATIO, type AspectRatio } from '@/constants/config'
+import { useImageUpload } from '@/hooks/use-image-upload'
+import { usePromptEnhance } from '@/hooks/use-prompt-enhance'
+
+interface UseGenerationFormOptions {
+  defaultAspectRatio?: string
+}
+
+/**
+ * Shared form state for generation forms (image, video, arena).
+ * Composes useImageUpload and usePromptEnhance with shared prompt/aspectRatio state.
+ */
+export function useGenerationForm(options?: UseGenerationFormOptions) {
+  const [prompt, setPrompt] = useState('')
+  const [aspectRatio, setAspectRatio] = useState<string>(
+    options?.defaultAspectRatio ?? DEFAULT_ASPECT_RATIO,
+  )
+
+  const imageUpload = useImageUpload()
+  const promptEnhance = usePromptEnhance()
+
+  const resetForm = useCallback(() => {
+    setPrompt('')
+    setAspectRatio(options?.defaultAspectRatio ?? DEFAULT_ASPECT_RATIO)
+    imageUpload.clearImage()
+    promptEnhance.clearEnhancement()
+  }, [options?.defaultAspectRatio, imageUpload, promptEnhance])
+
+  const applyEnhancedPrompt = useCallback(
+    (text: string) => {
+      setPrompt(text)
+      promptEnhance.clearEnhancement()
+    },
+    [promptEnhance],
+  )
+
+  return {
+    // Prompt state
+    prompt,
+    setPrompt,
+
+    // Aspect ratio state
+    aspectRatio: aspectRatio as AspectRatio,
+    setAspectRatio,
+
+    // Image upload (delegated)
+    ...imageUpload,
+
+    // Prompt enhancement (delegated)
+    isEnhancing: promptEnhance.isEnhancing,
+    enhanced: promptEnhance.enhanced,
+    enhancedOriginal: promptEnhance.original,
+    enhancedStyle: promptEnhance.style,
+    enhancePrompt: promptEnhance.enhance,
+    clearEnhancement: promptEnhance.clearEnhancement,
+
+    // Convenience
+    applyEnhancedPrompt,
+    resetForm,
+  }
+}

--- a/src/hooks/use-generation-visibility.ts
+++ b/src/hooks/use-generation-visibility.ts
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState, useCallback } from 'react'
+
+import { useRouter } from '@/i18n/navigation'
+import { toggleGenerationVisibility } from '@/lib/api-client'
+
+interface UseGenerationVisibilityOptions {
+  generationId: string
+  initialIsPublic: boolean
+  initialIsPromptPublic: boolean
+}
+
+interface UseGenerationVisibilityReturn {
+  isPublic: boolean
+  isPromptPublic: boolean
+  togglingField: string | null
+  handleToggle: (field: 'isPublic' | 'isPromptPublic') => Promise<void>
+}
+
+/**
+ * Shared hook for managing generation visibility toggles with optimistic updates.
+ * Used by ImageCard and ImageDetailModal.
+ */
+export function useGenerationVisibility({
+  generationId,
+  initialIsPublic,
+  initialIsPromptPublic,
+}: UseGenerationVisibilityOptions): UseGenerationVisibilityReturn {
+  const [isPublic, setIsPublic] = useState(initialIsPublic)
+  const [isPromptPublic, setIsPromptPublic] = useState(initialIsPromptPublic)
+  const [togglingField, setTogglingField] = useState<string | null>(null)
+  const router = useRouter()
+
+  const handleToggle = useCallback(
+    async (field: 'isPublic' | 'isPromptPublic') => {
+      if (togglingField) return
+      setTogglingField(field)
+
+      const setter = field === 'isPublic' ? setIsPublic : setIsPromptPublic
+      const prev = field === 'isPublic' ? isPublic : isPromptPublic
+
+      // Optimistic update
+      setter(!prev)
+
+      const result = await toggleGenerationVisibility(generationId, field)
+      if (!result.success) {
+        // Rollback on failure
+        setter(prev)
+      } else {
+        if (result.data) {
+          setIsPublic(result.data.isPublic)
+          setIsPromptPublic(result.data.isPromptPublic)
+        }
+        router.refresh()
+      }
+      setTogglingField(null)
+    },
+    [togglingField, isPublic, isPromptPublic, generationId, router],
+  )
+
+  return { isPublic, isPromptPublic, togglingField, handleToggle }
+}

--- a/src/hooks/use-image-upload.ts
+++ b/src/hooks/use-image-upload.ts
@@ -1,0 +1,96 @@
+'use client'
+
+import { useState, useCallback, useRef } from 'react'
+
+interface UseImageUploadReturn {
+  referenceImage: string | undefined
+  setReferenceImage: (image: string | undefined) => void
+  isDragging: boolean
+  setIsDragging: (dragging: boolean) => void
+  fileInputRef: React.RefObject<HTMLInputElement | null>
+  handleFileChange: (file: File) => Promise<void>
+  handleDrop: (e: React.DragEvent<HTMLDivElement>) => Promise<void>
+  handleDragOver: (e: React.DragEvent) => void
+  handleDragLeave: () => void
+  openFilePicker: () => void
+  handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>
+  clearImage: () => void
+}
+
+/**
+ * Shared hook for image upload via file picker or drag-and-drop.
+ * Used by GenerateForm, VideoGenerateForm, and ArenaForm.
+ */
+export function useImageUpload(): UseImageUploadReturn {
+  const [referenceImage, setReferenceImage] = useState<string | undefined>()
+  const [isDragging, setIsDragging] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const loadImageAsBase64 = useCallback((file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as string)
+      reader.onerror = reject
+      reader.readAsDataURL(file)
+    })
+  }, [])
+
+  const handleFileChange = useCallback(
+    async (file: File) => {
+      if (!file.type.startsWith('image/')) return
+      const base64 = await loadImageAsBase64(file)
+      setReferenceImage(base64)
+    },
+    [loadImageAsBase64],
+  )
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      setIsDragging(false)
+      const file = e.dataTransfer.files[0]
+      if (file) await handleFileChange(file)
+    },
+    [handleFileChange],
+  )
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragging(true)
+  }, [])
+
+  const handleDragLeave = useCallback(() => {
+    setIsDragging(false)
+  }, [])
+
+  const openFilePicker = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [])
+
+  const handleInputChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      if (file) await handleFileChange(file)
+    },
+    [handleFileChange],
+  )
+
+  const clearImage = useCallback(() => {
+    setReferenceImage(undefined)
+  }, [])
+
+  return {
+    referenceImage,
+    setReferenceImage,
+    isDragging,
+    setIsDragging,
+    fileInputRef,
+    handleFileChange,
+    handleDrop,
+    handleDragOver,
+    handleDragLeave,
+    openFilePicker,
+    handleInputChange,
+    clearImage,
+  }
+}

--- a/src/lib/model-options.ts
+++ b/src/lib/model-options.ts
@@ -1,0 +1,50 @@
+import { API_USAGE } from '@/constants/config'
+import { getModelMessageKey, isBuiltInModel } from '@/constants/models'
+import type { StudioModelOption } from '@/components/business/ModelSelector'
+import type { UserApiKeyRecord } from '@/types'
+
+/**
+ * Build saved model options from user's active API keys.
+ * Shared by GenerateForm, VideoGenerateForm, and ArenaForm.
+ */
+export function buildSavedModelOptions(
+  keys: UserApiKeyRecord[],
+  filter?: (key: UserApiKeyRecord) => boolean,
+): StudioModelOption[] {
+  const filtered = filter ? keys.filter(filter) : keys
+  return filtered.map((key) => ({
+    optionId: `key:${key.id}`,
+    modelId: key.modelId,
+    adapterType: key.adapterType,
+    providerConfig: key.providerConfig,
+    requestCount: API_USAGE.DEFAULT_REQUESTS_PER_GENERATION,
+    isBuiltIn: isBuiltInModel(key.modelId),
+    sourceType: 'saved' as const,
+    keyId: key.id,
+    keyLabel: key.label,
+    maskedKey: key.maskedKey,
+  }))
+}
+
+/**
+ * Find the selected model from options, falling back to first option.
+ */
+export function findSelectedModel<T extends { optionId: string }>(
+  options: T[],
+  selectedOptionId: string,
+): T | undefined {
+  return options.find((o) => o.optionId === selectedOptionId) ?? options[0]
+}
+
+/**
+ * Get translated model label for display.
+ */
+export function getTranslatedModelLabel(
+  tModels: (key: string, values?: Record<string, string | number>) => string,
+  modelId: string,
+): string {
+  if (isBuiltInModel(modelId)) {
+    return tModels(`${getModelMessageKey(modelId)}.label`)
+  }
+  return modelId
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,3 +8,16 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Get the label class name for metadata display, adjusting for CJK locales.
+ * Shared by ImageCard and ImageDetailModal.
+ */
+export function getLabelClassName(isDenseLocale: boolean) {
+  return cn(
+    'text-nav font-semibold text-muted-foreground',
+    isDenseLocale
+      ? 'tracking-normal normal-case'
+      : 'uppercase tracking-nav-dense',
+  )
+}


### PR DESCRIPTION
…dules

Extract 15 categories of duplicated code across 6 major components into reusable hooks and components. Net reduction of ~1300 lines while preserving all existing functionality.

New shared hooks:
- useAsyncAction<T> for generic async state management
- useImageUpload for drag-drop/file upload (replaces ~50 LOC per form)
- useGenerationVisibility for optimistic visibility toggles
- useGenerationForm composing upload + prompt enhance

New UI components:
- OptionGroup, AspectRatioSelector, CollapsiblePanel, ErrorAlert, ImageDropZone, ConfirmDialog, MetadataList

Decomposed large components:
- ApiKeyManager (1019 LOC) into ApiKeyForm + ApiKeyRow + ApiKeyHealthDot
- HomepageShell (455 LOC) into Hero + Features + Workflow + Models + SceneCard

Refactored forms to use shared abstractions:
- GenerateForm: 623 → ~350 LOC
- VideoGenerateForm: 490 → ~330 LOC
- ArenaForm: 583 → ~330 LOC (also fixed react-hooks/set-state-in-effect)