### PR TITLE
fix: correct NovelAI health check endpoint and key format validation

### DIFF
--- a/src/components/business/ApiKeyForm.tsx
+++ b/src/components/business/ApiKeyForm.tsx
@@ -67,8 +67,10 @@ function validateKeyFormat(
     case AI_ADAPTER_TYPES.REPLICATE:
       return trimmed.startsWith('r8_') ? 'valid' : 'invalid'
     case AI_ADAPTER_TYPES.NOVELAI:
-      // NovelAI persistent API tokens are JWT-like (eyJhbGci...)
-      return trimmed.length > 20 ? 'valid' : 'invalid'
+      // NovelAI persistent API tokens start with "pst-" or are JWT-like (eyJhbGci...)
+      return trimmed.startsWith('pst-') || trimmed.startsWith('eyJhbGci')
+        ? 'valid'
+        : 'invalid'
   }
 }
 

--- a/src/constants/providers.ts
+++ b/src/constants/providers.ts
@@ -59,7 +59,7 @@ export const ADAPTER_KEY_HINTS: Record<AI_ADAPTER_TYPES, string> = {
   [AI_ADAPTER_TYPES.OPENAI]: 'sk-proj-...',
   [AI_ADAPTER_TYPES.FAL]: 'fal_...',
   [AI_ADAPTER_TYPES.REPLICATE]: 'r8_...',
-  [AI_ADAPTER_TYPES.NOVELAI]: 'eyJhbGci...',
+  [AI_ADAPTER_TYPES.NOVELAI]: 'pst-...',
 }
 
 export const ADAPTER_DEFAULT_COSTS: Record<AI_ADAPTER_TYPES, number> = {

--- a/src/services/providers/novelai.adapter.ts
+++ b/src/services/providers/novelai.adapter.ts
@@ -126,7 +126,7 @@ export const novelAiAdapter: ProviderAdapter = {
   async healthCheck({ apiKey, baseUrl, timeoutMs }: HealthCheckInput) {
     const start = Date.now()
     try {
-      const endpoint = `${baseUrl}/user/information`
+      const endpoint = `${baseUrl}/user/subscription`
       const response = await fetch(endpoint, {
         method: 'GET',
         headers: { Authorization: `Bearer ${apiKey}` },


### PR DESCRIPTION
Health check now uses /user/subscription instead of the non-existent /user/information endpoint. Key validation accepts both pst- (persistent token) and JWT formats. Key hint updated to show pst- prefix.