### PR TITLE
chore: sync CLAUDE.md fanout numbers + Tailwind v4 hard rule

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -26,7 +26,7 @@ Personal AI Gallery (PixelVault) — multi-model AI image generation + permanent
 2. **No `any`** — define types via Zod schemas, infer with `z.infer<typeof schema>`
 3. **No fetch in components** — all API calls go through `src/lib/api-client.ts`
 4. **API routes do 3 things only** — auth check → Zod validate → call service
-5. **No Tailwind arbitrary values** — extend `tailwind.config.ts` instead
+5. **No Tailwind arbitrary values** — extend the `@theme` block in `src/app/globals.css` instead (project uses Tailwind v4, there is no `tailwind.config.ts`)
 6. **Feature dev order** — constants → types → services → hooks → components
 7. **Import order** — React/Next → third-party → internal constants/types → components/hooks → styles
 
@@ -147,11 +147,11 @@ See `docs/reference/design-system.md` for full spec. Key constraints:
 高风险模块（改动前必须确认影响范围）：
 
 - `src/types/index.ts` — 189 files depend on it (see `src/types/CLAUDE.md`)
-- `src/services/user.service.ts` — 22 files depend on it
+- `src/services/user.service.ts` — 90 files depend on it
 - `src/services/generate-image.service.ts` — orchestrator, 8+ service deps
-- `src/contexts/studio-context.tsx` — 23+ studio components (see `src/contexts/CLAUDE.md`)
-- `src/constants/models.ts` — 178 files import from constants (see `src/constants/CLAUDE.md`)
-- `src/services/storage/r2.ts` — 15 services depend on it
+- `src/contexts/studio-context.tsx` — 46 consumer files (see `src/contexts/CLAUDE.md`)
+- `src/constants/models.ts` — 68 files depend on it (see `src/constants/CLAUDE.md`)
+- `src/services/storage/r2.ts` — 24 files depend on it
 
 Per-directory CLAUDE.md files exist in: `types/`, `contexts/`, `components/business/studio/`, `hooks/`, `constants/`
 

--- a/src/contexts/CLAUDE.md
+++ b/src/contexts/CLAUDE.md
@@ -1,6 +1,6 @@
 # src/contexts/ — React Context Providers
 
-## Risk Level: HIGH (Studio context drives 23+ components)
+## Risk Level: HIGH (Studio context drives 46 consumer files)
 
 ## Studio Context Split (3 providers by update frequency)
 
@@ -10,7 +10,7 @@ StudioDataContext  (WARM) — cards, projects, civitai, upload — changes on us
 StudioGenContext   (COLD) — generation state — changes only during generation
 ```
 
-**Why split?** Putting fast-changing state (prompt text) in the same context as slow-changing state (cards list) causes unnecessary re-renders across 23+ components. The split prevents cascade renders.
+**Why split?** Putting fast-changing state (prompt text) in the same context as slow-changing state (cards list) causes unnecessary re-renders across 46 consumer files. The split prevents cascade renders.
 
 ## Rules
 
@@ -36,11 +36,11 @@ StudioDataContext initializes these hooks at mount time:
 
 ## Consumer Hooks
 
-| Hook              | Context     | Consumers      |
-| ----------------- | ----------- | -------------- |
-| `useStudioForm()` | FormContext | ~43 components |
-| `useStudioData()` | DataContext | ~26 components |
-| `useStudioGen()`  | GenContext  | ~18 components |
+| Hook              | Context     | Consumers         |
+| ----------------- | ----------- | ----------------- |
+| `useStudioForm()` | FormContext | 34 consumer files |
+| `useStudioData()` | DataContext | 19 consumer files |
+| `useStudioGen()`  | GenContext  | 16 consumer files |
 
 ## Change Checklist
 


### PR DESCRIPTION
## Summary

plan-eng-review (2026-05-05) found the CLAUDE.md docs had drifted from reality. This is a docs-only chore PR that brings them back in sync — no code changes.

## Changes

**Root `CLAUDE.md` — Hard rule #5**

Hard rule #5 still pointed at `tailwind.config.ts`, but this project moved to Tailwind v4 and the config now lives in the `@theme {}` block in `src/app/globals.css`. There is no `tailwind.config.ts` to extend.

- Old: `extend tailwind.config.ts instead`
- New: `extend the @theme block in src/app/globals.css instead (project uses Tailwind v4, there is no tailwind.config.ts)`

**Root `CLAUDE.md` — High-risk module fanout (Change Safety Protocol)**

Verified each count by `grep -rl "from '@/<module>'" src/ | wc -l`:

| Module | Old | Verified |
| --- | --- | --- |
| `src/services/user.service.ts` | 22 | **90** |
| `src/services/storage/r2.ts` | 15 | **24** |
| `src/constants/models.ts` | 178 | **68** |
| `src/contexts/studio-context.tsx` | 23+ | **46** |

(`src/types/index.ts` at 189 and `generate-image.service.ts` at "8+ service deps" were not flagged for re-verification this round and are left untouched.)

**`src/contexts/CLAUDE.md` — Studio context fanout**

Three references to "23+ components" updated to "46 consumer files" (verified via `grep -rl "useStudio\|StudioFormContext\|StudioDataContext\|StudioGenContext" src/`). Consumer Hooks table refreshed with grep-measured per-hook counts:

| Hook | Old | Verified |
| --- | --- | --- |
| `useStudioForm()` | ~43 | **34** |
| `useStudioData()` | ~26 | **19** |
| `useStudioGen()` | ~18 | **16** |

## Test plan

- [x] `npm run check:node`, `eslint`, full vitest suite pass on pre-push hook (186 files, 1325 tests)
- [x] No code or runtime changes — docs-only diff